### PR TITLE
Migrate ComputeTaskDef to golem-messages.

### DIFF
--- a/golem_messages/datastructures.py
+++ b/golem_messages/datastructures.py
@@ -1,0 +1,20 @@
+import copy
+
+
+class FrozenDict(dict):
+    """FrozenDict allows only values provided in ITEMS attribute. It also acts
+       as DefaultDict with values from ITEMS.
+       """
+
+    ITEMS = {}
+
+    def __missing__(self, key):
+        return copy.deepcopy(self.ITEMS[key])
+
+    def __setitem__(self, key, value):
+        if key not in self.ITEMS:
+            raise KeyError("Invalid key: {}".format(key))
+        return super().__setitem__(key, value)
+
+    def __setattr__(self, key, value):
+        raise AttributeError("Read only. Use mapping interface")

--- a/golem_messages/datastructures.py
+++ b/golem_messages/datastructures.py
@@ -2,7 +2,7 @@ import copy
 
 
 class FrozenDict(dict):
-    """FrozenDict allows only values provided in ITEMS attribute. It also acts
+    """FrozenDict allows only keys provided in ITEMS attribute. It also acts
        as DefaultDict with values from ITEMS.
        """
 

--- a/golem_messages/message.py
+++ b/golem_messages/message.py
@@ -41,7 +41,7 @@ class ComputeTaskDef(datastructures.FrozenDict):
         'subtask_id': '',
         'deadline': '',
         'src_code': '',
-        'extra_data': None,  # initialized to dict later on
+        'extra_data': {},  # safe because of copy in parent.__missing__()
         'short_description': '',
         'return_address': '',
         'return_port': 0,
@@ -52,10 +52,6 @@ class ComputeTaskDef(datastructures.FrozenDict):
         'environment': '',
         'docker_images': None,
     }
-
-    def __init__(self, *args, **kwargs):
-        self['extra_data'] = {}
-        super().__init__(*args, **kwargs)
 
 
 # Message types that are allowed to be sent in the network

--- a/golem_messages/message.py
+++ b/golem_messages/message.py
@@ -7,6 +7,7 @@ import struct
 import time
 from typing import Optional
 
+from . import datastructures
 from . import exceptions
 from . import serializer
 from . import settings
@@ -34,22 +35,7 @@ def verify_time(timestamp):
         raise exceptions.MessageFromFutureError()
 
 
-class FrozenDict(dict):
-    ITEMS = {}
-
-    def __missing__(self, key):
-        return self.ITEMS[key]
-
-    def __setitem__(self, key, value):
-        if key not in self.ITEMS:
-            raise KeyError("Invalid key: {}".format(key))
-        return super().__setitem__(key, value)
-
-    def __setattr__(self, key, value):
-        raise AttributeError("Read only. Use mapping interface")
-
-
-class ComputeTaskDef(FrozenDict):
+class ComputeTaskDef(datastructures.FrozenDict):
     ITEMS = {
         'task_id': '',
         'subtask_id': '',

--- a/golem_messages/message.py
+++ b/golem_messages/message.py
@@ -34,6 +34,41 @@ def verify_time(timestamp):
         raise exceptions.MessageFromFutureError()
 
 
+class FrozenDict(dict):
+    ITEMS = {}
+
+    def __missing__(self, key):
+        return self.ITEMS[key]
+
+    def __setitem__(self, key, value):
+        if key not in self.ITEMS:
+            raise KeyError("Invalid key: {}".format(key))
+        return super().__setitem__(key, value)
+
+
+class ComputeTaskDef(FrozenDict):
+    ITEMS = {
+        'task_id': '',
+        'subtask_id': '',
+        'deadline': '',
+        'src_code': '',
+        'extra_data': None,  # initialized to dict later on
+        'short_description': '',
+        'return_address': '',
+        'return_port': 0,
+        'task_owner': None,
+        'key_id': 0,
+        'working_directory': '',
+        'performance': 0,
+        'environment': '',
+        'docker_images': None,
+    }
+
+    def __init__(self, *args, **kwargs):
+        self['extra_data'] = {}
+        super().__init__(*args, **kwargs)
+
+
 # Message types that are allowed to be sent in the network
 registered_message_types = {}
 

--- a/golem_messages/message.py
+++ b/golem_messages/message.py
@@ -45,6 +45,9 @@ class FrozenDict(dict):
             raise KeyError("Invalid key: {}".format(key))
         return super().__setitem__(key, value)
 
+    def __setattr__(self, key, value):
+        raise AttributeError("Read only. Use mapping interface")
+
 
 class ComputeTaskDef(FrozenDict):
     ITEMS = {

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -22,6 +22,22 @@ class FrozenTestCase(unittest.TestCase):
 
         self.assertEqual(fd['default'], default_value)
 
+    def test_aliasing(self):
+        """Aliasing of objects in python is a dangerous pitfall. (SEE alising
+           in python). There is a countermeasure in __missing__(). Lets
+           test it.
+        """
+
+        class TestDict(datastructures.FrozenDict):
+            ITEMS = {
+                'dict': {},
+            }
+
+        fd = TestDict()
+        fd['dict']['watch out'] = 'for aliasing'
+        fd2 = TestDict()
+        self.assertEqual(fd2['dict'], {})
+
     def test_new_key(self):
         fd = datastructures.FrozenDict()
         with self.assertRaises(KeyError):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -26,3 +26,10 @@ class FrozenTestCase(unittest.TestCase):
         fd = FrozenDict()
         with self.assertRaises(KeyError):
             fd['new_key'] = 'Mexico military crime-busters join ocean...'
+
+    def test_set_attr(self):
+        fd = FrozenDict()
+        with self.assertRaises(AttributeError):
+            fd.new_attr = ('Pod moskitierą czuło się duchotę, przy oknie — '
+                           'gorąc zupełnie tropikalny.'
+                           )

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,6 +1,6 @@
 import unittest
 
-from golem_messages.message import FrozenDict
+from golem_messages import datastructures
 
 
 class FrozenTestCase(unittest.TestCase):
@@ -11,7 +11,7 @@ class FrozenTestCase(unittest.TestCase):
                          "diverse characters who explore them in Manifesto."
                          )
 
-        class TestDict(FrozenDict):
+        class TestDict(datastructures.FrozenDict):
             ITEMS = {
                 'default': default_value,
             }
@@ -23,12 +23,12 @@ class FrozenTestCase(unittest.TestCase):
         self.assertEqual(fd['default'], default_value)
 
     def test_new_key(self):
-        fd = FrozenDict()
+        fd = datastructures.FrozenDict()
         with self.assertRaises(KeyError):
             fd['new_key'] = 'Mexico military crime-busters join ocean...'
 
     def test_set_attr(self):
-        fd = FrozenDict()
+        fd = datastructures.FrozenDict()
         with self.assertRaises(AttributeError):
             fd.new_attr = ('Pod moskitierą czuło się duchotę, przy oknie — '
                            'gorąc zupełnie tropikalny.'

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,0 +1,28 @@
+import unittest
+
+from golem_messages.message import FrozenDict
+
+
+class FrozenTestCase(unittest.TestCase):
+    def test_missing(self):
+        default_value = ("You may not know much about 20th-century art"
+                         "manifestos, but you'll know what you like with"
+                         "Cate Blanchett's stunning turn as 13 wildly"
+                         "diverse characters who explore them in Manifesto."
+                         )
+
+        class TestDict(FrozenDict):
+            ITEMS = {
+                'default': default_value,
+            }
+
+        fd = TestDict()
+        with self.assertRaises(KeyError):
+            fd['missing']
+
+        self.assertEqual(fd['default'], default_value)
+
+    def test_new_key(self):
+        fd = FrozenDict()
+        with self.assertRaises(KeyError):
+            fd['new_key'] = 'Mexico military crime-busters join ocean...'


### PR DESCRIPTION
fixes: #6

As `ComputeTaskDef` was already only a mapping container I've also re factored it to implement mapping interface. It also allowed to catch implementation errors (invalid attributes).