### PR TITLE
Provide payment timestamp in SubtaskResultAccepted

### DIFF
--- a/golem_messages/message.py
+++ b/golem_messages/message.py
@@ -873,17 +873,15 @@ class SubtaskResultAccepted(Message):
 
     __slots__ = [
         'subtask_id',
-        'reward'
+        'payment_ts'
     ] + Message.__slots__
 
-    def __init__(self, subtask_id=0, reward=0, **kwargs):
+    def __init__(self, subtask_id: str="", payment_ts: int=0, **kwargs):
         """
         Create message with information that subtask result was accepted
-        :param str subtask_id: accepted subtask id
-        :param float reward: payment for computations
         """
         self.subtask_id = subtask_id
-        self.reward = reward
+        self.payment_ts = payment_ts
         super().__init__(**kwargs)
 
 


### PR DESCRIPTION
`reward` isn't used nor useful anyway.
Payment timestamp is needed for the provider to correctly identify all the payments requestor has paid for during `batchTransfer` (all payments with timestamp <= `closure_time`)