### PR TITLE
Initialize slots with None

### DIFF
--- a/golem_messages/message.py
+++ b/golem_messages/message.py
@@ -93,13 +93,14 @@ class Message():
     ENUM_SLOTS = {}
 
     def __init__(self, timestamp=None, encrypted=False, sig=None,
-                 raw=None, slots=None, **kwargs):
+                 raw=None, slots=None, deserialized=False, **kwargs):
 
         """Create a new message
         :param timestamp: message timestamp
         :param encrypted: whether message was encrypted
         :param sig: signed message hash
         :param raw: original message bytes
+        :param deserialized: was message created by .deserialize()?
         """
 
         # Child message slots
@@ -273,7 +274,8 @@ class Message():
                 encrypted=msg_enc,
                 sig=sig,
                 raw=msg,
-                slots=slots
+                slots=slots,
+                deserialized=True,
             )
         except Exception as exc:
             logger.info("Message error: invalid data: %r", exc)
@@ -356,7 +358,8 @@ class Hello(Message):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if self.golem_messages_version is None:
+        deserialized = kwargs.pop('deserialized', False)
+        if not deserialized and self.golem_messages_version is None:
             self.golem_messages_version = golem_messages.__version__
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -94,6 +94,9 @@ class BasicTestCase(unittest.TestCase):
         msg = message.Hello()
         self.assertEqual(msg.golem_messages_version, v_mock)
 
+        msg = message.Hello(deserialized=True)
+        self.assertIsNone(msg.golem_messages_version)
+
         version_kwarg = object()
         msg_kwarg = message.Hello(golem_messages_version=version_kwarg)
         self.assertEqual(msg_kwarg.golem_messages_version, version_kwarg)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -94,6 +94,16 @@ class BasicTestCase(unittest.TestCase):
         msg = message.Hello()
         self.assertEqual(msg.golem_messages_version, v_mock)
 
+        version_kwarg = object()
+        msg_kwarg = message.Hello(golem_messages_version=version_kwarg)
+        self.assertEqual(msg_kwarg.golem_messages_version, version_kwarg)
+
+        version_slot = object()
+        msg_slot = message.Hello(
+            slots=[('golem_messages_version', version_slot), ],
+        )
+        self.assertEqual(msg_slot.golem_messages_version, version_slot)
+
     @mock.patch("golem_messages.message.RandVal")
     def test_init_messages_error(self, mock_message_rand_val):
         copy_registered = dict(message.registered_message_types)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -10,6 +10,35 @@ from golem_messages import shortcuts
 
 
 class MessagesTestCase(unittest.TestCase):
+    def test_default_slots(self):
+        """Slots initialization to None"""
+        msg = message.Hello()
+        for key in msg.__slots__:
+            if key in message.Message.__slots__:
+                continue
+            if key == 'golem_messages_version':
+                continue
+            self.assertIsNone(getattr(msg, key))
+
+    def test_kwarg(self):
+        node_name = 'Tuż nad Bugiem, z lewej strony,'
+        msg = message.Hello(node_name=node_name)
+        self.assertEqual(msg.node_name, node_name)
+
+    def test_slot(self):
+        node_name = 'Tuż nad Bugiem, z lewej strony,'
+        msg = message.Hello(slots=[('node_name', node_name), ])
+        self.assertEqual(msg.node_name, node_name)
+
+    def test_kwarg_and_slot(self):
+        node_name_kwarg = 'Tuż nad Bugiem, z lewej strony,'
+        node_name_slot = 'Stoi wielki bór zielony.'
+        msg = message.Hello(
+            node_name=node_name_kwarg,
+            slots=[('node_name', node_name_slot), ],
+        )
+        self.assertEqual(msg.node_name, node_name_slot)
+
     def test_message_want_to_compute_task(self):
         node_id = 'test-ni-{}'.format(uuid.uuid4())
         task_id = 'test-ti-{}'.format(uuid.uuid4())


### PR DESCRIPTION
 * all message slots are initialized to `None` to avoid `AttributeErrors`
   in client code
 * slot values have preference over kwarg values (in other words kwarg
   values are treated as defaults, and values received over the wire are
   prioritized)