### PR TITLE
Disable sharing values in cbor

### DIFF
--- a/golem_messages/serializer.py
+++ b/golem_messages/serializer.py
@@ -204,6 +204,7 @@ dumps = functools.partial(
     encoders=ENCODERS,
     datetime_as_timestamp=True,
     timezone=pytz.utc,
+    value_sharing=False,
 )
 
 


### PR DESCRIPTION
We don't benefit from that and it only makes Go implementation more complicated.
Note: it's not backwards compatible.