### PR TITLE
Load OpenSSL smarter on windows

### DIFF
--- a/golem_messages/cryptography.py
+++ b/golem_messages/cryptography.py
@@ -302,3 +302,12 @@ class ECCx(pyelliptic.ECC):
         return ctx.ciphering(ciphertext)
     encrypt = ecies_encrypt
     decrypt = ecies_decrypt
+
+    def sign(self, data):
+        signature = ecdsa_sign(data, self.raw_privkey)
+        assert len(signature) == 65
+        return signature
+
+    def verify(self, signature, message):
+        assert len(signature) == 65
+        return ecdsa_verify(self.raw_pubkey, signature, message)

--- a/golem_messages/cryptography.py
+++ b/golem_messages/cryptography.py
@@ -126,6 +126,7 @@ def ecdsa_verify(pubkey, signature, message):
     )
     if not pk.format(compressed=False) == b'\04' + pubkey:
         raise exceptions.InvalidSignature()
+    return True
 
 
 class ECCx(pyelliptic.ECC):

--- a/golem_messages/cryptography.py
+++ b/golem_messages/cryptography.py
@@ -109,6 +109,11 @@ def sha3(seed):
 
 
 def mk_privkey(seed):
+    """ Return sha3-256 (keccak) of seed in digest
+    TODO: Remove keccak when decoupled from ethereum privatekey
+    :param str seed: data that should be hashed
+    :return str: binary hashed data
+    """
     def sha3_256_kec(x):
         from Crypto.Hash import keccak
         return keccak.new(digest_bits=256, data=rlp_utils.str_to_bytes(x))

--- a/golem_messages/cryptography.py
+++ b/golem_messages/cryptography.py
@@ -109,7 +109,10 @@ def sha3(seed):
 
 
 def mk_privkey(seed):
-    return sha3(seed)
+    def sha3_256_kec(x):
+        from Crypto.Hash import keccak
+        return keccak.new(digest_bits=256, data=rlp_utils.str_to_bytes(x))
+    return sha3_256_kec(seed).digest()
 
 
 def ecdsa_sign(privkey, msghash):

--- a/golem_messages/cryptography.py
+++ b/golem_messages/cryptography.py
@@ -2,7 +2,6 @@ import os
 import sys
 import struct
 import hashlib
-
 import bitcoin
 import coincurve
 from rlp import utils as rlp_utils

--- a/golem_messages/cryptography.py
+++ b/golem_messages/cryptography.py
@@ -305,7 +305,7 @@ class ECCx(pyelliptic.ECC):
     decrypt = ecies_decrypt
 
     def sign(self, data):
-        signature = ecdsa_sign(data, self.raw_privkey)
+        signature = ecdsa_sign(self.raw_privkey, data)
         assert len(signature) == 65
         return signature
 

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -28,7 +28,8 @@
 
 from unittest import TestCase
 
-from golem_messages.cryptography import ECCx, mk_privkey, privtopub
+from golem_messages.cryptography import ECCx, mk_privkey, privtopub, sha3, \
+        ecdsa_verify
 
 from golem_messages import exceptions
 
@@ -46,6 +47,21 @@ class TestCrypto(TestCase):
         plaintext = b"Hello Bob"
         ciphertext = ECCx.encrypt(plaintext, bob.raw_pubkey)
         assert bob.decrypt(ciphertext) == plaintext
+
+    def test_signature(self):
+        bob = get_ecc('secret2')
+
+        # sign
+        message = sha3("Hello Alice")
+        signature = bob.sign(message)
+
+        # verify signature
+        assert ecdsa_verify(bob.raw_pubkey, signature, message) is True
+
+        # wrong signature
+        message = sha3("Hello Alicf")
+        with self.assertRaises(exceptions.InvalidSignature):
+            ecdsa_verify(bob.raw_pubkey, signature, message)
 
     def test_en_decrypt(self):
         alice = ECCx(None)

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -1,0 +1,75 @@
+# Based on:
+# https://github.com/ethereum/pydevp2p/blob/develop/devp2p/tests/test_crypto.py
+#
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Heiko Hees
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#
+
+from unittest import TestCase
+
+from golem_messages.cryptography import ECCx, mk_privkey, privtopub
+
+from golem_messages import exceptions
+
+
+def get_ecc(secret=''):
+    return ECCx(raw_privkey=mk_privkey(secret))
+
+
+class TestCrypto(TestCase):
+
+    def test_asymetric(self):
+        bob = get_ecc('secret2')
+
+        # enc / dec
+        plaintext = b"Hello Bob"
+        ciphertext = ECCx.encrypt(plaintext, bob.raw_pubkey)
+        assert bob.decrypt(ciphertext) == plaintext
+
+    def test_en_decrypt(self):
+        alice = ECCx(None)
+        bob = ECCx(None)
+        msg = b'test'
+        ciphertext = alice.encrypt(msg, bob.raw_pubkey)
+        assert bob.decrypt(ciphertext) == msg
+
+    def test_en_decrypt_shared_mac_data(self):
+        alice, bob = ECCx(None), ECCx(None)
+        ciphertext = alice.encrypt(b'test', bob.raw_pubkey,
+                                   shared_mac_data=b'shared mac data')
+        assert bob.decrypt(ciphertext,
+                           shared_mac_data=b'shared mac data') == b'test'
+
+    def test_en_decrypt_shared_mac_data_fail(self):
+        with self.assertRaises(exceptions.DecryptionError):
+            alice, bob = ECCx(None), ECCx(None)
+            ciphertext = alice.encrypt(b'test', bob.raw_pubkey,
+                                       shared_mac_data=b'shared mac data')
+            bob.decrypt(ciphertext, shared_mac_data=b'wrong')
+
+    def test_privtopub(self):
+        priv = mk_privkey('test')
+        pub = privtopub(priv)
+        pub2 = ECCx(raw_privkey=priv).raw_pubkey
+        assert pub == pub2

--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -40,7 +40,7 @@ def get_ecc(secret=''):
 
 class TestCrypto(TestCase):
 
-    def test_asymetric(self):
+    def test_asymmetric(self):
         bob = get_ecc('secret2')
 
         # enc / dec


### PR DESCRIPTION
Required for PR golemfactory/golem#1782 and issue golemfactory/golem#1612.

- Added windows load hack made for golemfactory/golem#1612
- Removed `golem.core.crypto` and started using `golem_messages.cryptography` everywhere.
- Moved `crypto` test and tweaked them for `cryptography`