### PR TITLE
Adjust names of .*SubtaskResult.* messages

### DIFF
--- a/golem_messages/message/__init__.py
+++ b/golem_messages/message/__init__.py
@@ -33,8 +33,6 @@ from golem_messages.message.tasks import TaskFailure  # noqa
 from golem_messages.message.tasks import GetTaskResult  # noqa
 from golem_messages.message.tasks import StartSessionResponse  # noqa
 from golem_messages.message.tasks import WaitingForResults  # noqa
-from golem_messages.message.tasks import SubtaskResultAccepted  # noqa
-from golem_messages.message.tasks import SubtaskResultRejected  # noqa
 from golem_messages.message.tasks import DeltaParts  # noqa
 from golem_messages.message.tasks import SubtaskPayment  # noqa
 from golem_messages.message.tasks import SubtaskPaymentRequest  # noqa
@@ -110,8 +108,8 @@ def init_messages():
             tasks.StartSessionResponse,
 
             tasks.WaitingForResults,
-            tasks.SubtaskResultAccepted,
-            tasks.SubtaskResultRejected,
+            tasks.SubtaskResultsAccepted,
+            tasks.SubtaskResultsRejected,
             tasks.DeltaParts,
             tasks.GetResource,
 
@@ -137,9 +135,9 @@ def init_messages():
             concents.RejectReportComputedTask,
             concents.VerdictReportComputedTask,
             concents.FileTransferToken,
-            concents.SubtaskResultVerify,
-            concents.AckSubtaskResultVerify,
-            concents.SubtaskResultSettled,
+            concents.SubtaskResultsVerify,
+            concents.AckSubtaskResultsVerify,
+            concents.SubtaskResultsSettled,
             concents.ForceGetTaskResult,
             concents.ForceGetTaskResultAck,
             concents.ForceGetTaskResultFailed,

--- a/golem_messages/message/concents.py
+++ b/golem_messages/message/concents.py
@@ -137,12 +137,12 @@ class FileTransferToken(base.Message):
         }
 
 
-class SubtaskResultVerify(base.Message):
+class SubtaskResultsVerify(base.Message):
     """
     Message sent from a Provider to the Concent, requesting additional
     verification in case the result had been rejected by the Requestor
 
-    :param (slot)SubtaskResultRejected subtask_result_rejected:
+    :param (slot)SubtaskResultsRejected subtask_result_rejected:
            the original reject message
 
     """
@@ -157,14 +157,14 @@ class SubtaskResultVerify(base.Message):
             key,
             super().deserialize_slot(key, value),
             verify_key='subtask_result_rejected',
-            verify_class=tasks.SubtaskResultRejected
+            verify_class=tasks.SubtaskResultsRejected
         )
 
 
-class AckSubtaskResultVerify(base.Message):
+class AckSubtaskResultsVerify(base.Message):
     """
     Message sent from the Concent to the Provider to acknowledge reception
-    of the `SubtaskResultVerify` message
+    of the `SubtaskResultsVerify` message
     """
     TYPE = CONCENT_MSG_BASE + 7
 
@@ -177,17 +177,17 @@ class AckSubtaskResultVerify(base.Message):
             key,
             super().deserialize_slot(key, value),
             verify_key='subtask_result_verify',
-            verify_class=SubtaskResultVerify
+            verify_class=SubtaskResultsVerify
         )
 
 
-class SubtaskResultSettled(base.Message):
+class SubtaskResultsSettled(base.Message):
     """
     Message sent from the Concent to both the Provider and the Requestor
     informing of positive acceptance of the results by the Concent and the
     fact that the payment has been force-sent to the Provider
 
-    :param (slot)str origin: the origin of the `SubtaskResultVerify` message
+    :param (slot)str origin: the origin of the `SubtaskResultsVerify` message
                              that triggered the Concent action
 
     :param (slot)TaskToCompute task_to_compute: TTF containing the task

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -146,7 +146,7 @@ class GetResource(base.Message):
     ] + base.Message.__slots__
 
 
-class SubtaskResultAccepted(base.Message):
+class SubtaskResultsAccepted(base.Message):
     TYPE = TASK_MSG_BASE + 10
 
     __slots__ = [
@@ -154,18 +154,11 @@ class SubtaskResultAccepted(base.Message):
         'payment_ts'
     ] + base.Message.__slots__
 
-#
-# @todo for consistency's sake, the name of this message class should be:
-#       `SubtaskResultsRejected` (+ that's what's specified in the docs)
-#
-#       https://github.com/golemfactory/golem-messages/issues/96
-#
 
-class SubtaskResultRejected(base.Message):
+class SubtaskResultsRejected(base.Message):
     TYPE = TASK_MSG_BASE + 11
 
     __slots__ = ['subtask_id'] + base.Message.__slots__
-
 
 
 class DeltaParts(base.Message):
@@ -252,7 +245,7 @@ class CannotComputeTask(base.AbstractReasonMessage):
 
 class SubtaskPayment(base.Message):
     """Informs about payment for a subtask.
-    It succeeds SubtaskResultAccepted but could
+    It succeeds SubtaskResultsAccepted but could
     be sent after a delay. It is also sent in response to
     SubtaskPaymentRequest. If transaction_id is None it
     should be interpreted as PAYMENT PENDING status.

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,11 +2,11 @@ import uuid
 import factory
 
 from golem_messages.message.tasks import (
-    ComputeTaskDef, TaskToCompute, SubtaskResultRejected, ReportComputedTask,
+    ComputeTaskDef, TaskToCompute, SubtaskResultsRejected, ReportComputedTask,
 )
 
 from golem_messages.message.concents import (
-    SubtaskResultVerify, AckSubtaskResultVerify, SubtaskResultSettled,
+    SubtaskResultsVerify, AckSubtaskResultsVerify, SubtaskResultsSettled,
     ForceGetTaskResult, ForceGetTaskResultAck, ForceGetTaskResultFailed,
     ForceGetTaskResultRejected, ForceGetTaskResultUpload,
     ForceReportComputedTask, FileTransferToken,
@@ -26,7 +26,7 @@ class SlotsFactory(factory.Factory):
 
     :Example:
 
-    SubtaskResultVerifyFactory(slots__subtask_id='some-id')
+    SubtaskResultsVerifyFactory(slots__subtask_id='some-id')
 
     """
 
@@ -78,9 +78,9 @@ class TaskToComputeFactory(factory.Factory):
     slots = factory.SubFactory(TaskToComputeSlotsFactory)
 
 
-class SubtaskResultRejectedFactory(factory.Factory):
+class SubtaskResultsRejectedFactory(factory.Factory):
     class Meta:
-        model = SubtaskResultRejected
+        model = SubtaskResultsRejected
 
     slots = factory.SubFactory(SlotsFactory,
                                subtask_id='test-si-{}'.format(uuid.uuid4()))
@@ -114,53 +114,53 @@ class ForceReportComputedTaskFactory(factory.Factory):
     slots = factory.SubFactory(ForceReportComputedTaskSlotsFactory)
 
 
-class SubtaskResultVerifySlotsFactory(SlotsFactory):
+class SubtaskResultsVerifySlotsFactory(SlotsFactory):
     class Meta:
         model = tuple
 
-    subtask_result_rejected = factory.SubFactory(SubtaskResultRejectedFactory)
+    subtask_result_rejected = factory.SubFactory(SubtaskResultsRejectedFactory)
 
 
-class SubtaskResultVerifyFactory(factory.Factory):
+class SubtaskResultsVerifyFactory(factory.Factory):
     class Meta:
-        model = SubtaskResultVerify
+        model = SubtaskResultsVerify
 
-    slots = factory.SubFactory(SubtaskResultVerifySlotsFactory)
-
-
-class AckSubtaskResultVerifySlotsFactory(SlotsFactory):
-    class Meta:
-        model = tuple
-
-    subtask_result_verify = factory.SubFactory(SubtaskResultVerifyFactory)
+    slots = factory.SubFactory(SubtaskResultsVerifySlotsFactory)
 
 
-class AckSubtaskResultVerifyFactory(factory.Factory):
-    class Meta:
-        model = AckSubtaskResultVerify
-
-    slots = factory.SubFactory(AckSubtaskResultVerifySlotsFactory)
-
-
-class SubtaskResultSettledSlotsFactory(SlotsFactory):
+class AckSubtaskResultsVerifySlotsFactory(SlotsFactory):
     class Meta:
         model = tuple
 
-    origin = SubtaskResultSettled.Origin.ResultsAcceptedTimeout
+    subtask_result_verify = factory.SubFactory(SubtaskResultsVerifyFactory)
+
+
+class AckSubtaskResultsVerifyFactory(factory.Factory):
+    class Meta:
+        model = AckSubtaskResultsVerify
+
+    slots = factory.SubFactory(AckSubtaskResultsVerifySlotsFactory)
+
+
+class SubtaskResultsSettledSlotsFactory(SlotsFactory):
+    class Meta:
+        model = tuple
+
+    origin = SubtaskResultsSettled.Origin.ResultsAcceptedTimeout
     task_to_compute = factory.SubFactory(TaskToComputeFactory)
 
 
-class SubtaskResultSettledFactory(factory.Factory):
+class SubtaskResultsSettledFactory(factory.Factory):
     class Meta:
-        model = SubtaskResultSettled
+        model = SubtaskResultsSettled
 
-    slots = factory.SubFactory(SubtaskResultSettledSlotsFactory)
+    slots = factory.SubFactory(SubtaskResultsSettledSlotsFactory)
 
     @classmethod
     def origin_acceptance_timeout(cls, *args, **kwargs):
         kwargs.update({
             'slots__origin':
-                SubtaskResultSettled.Origin.ResultsAcceptedTimeout
+                SubtaskResultsSettled.Origin.ResultsAcceptedTimeout
         })
         return cls(*args, **kwargs)
 
@@ -168,7 +168,7 @@ class SubtaskResultSettledFactory(factory.Factory):
     def origin_results_rejected(cls, *args, **kwargs):
         kwargs.update({
             'slots__origin':
-                SubtaskResultSettled.Origin.ResultsRejected
+                SubtaskResultsSettled.Origin.ResultsRejected
         })
         return cls(*args, **kwargs)
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -12,8 +12,8 @@ from golem_messages import shortcuts
 from .factories import (
     TaskToComputeFactory,
     ReportComputedTaskFactory, ForceReportComputedTaskFactory,
-    SubtaskResultRejectedFactory, SubtaskResultVerifyFactory,
-    AckSubtaskResultVerifyFactory, SubtaskResultSettledFactory,
+    SubtaskResultsRejectedFactory, SubtaskResultsVerifyFactory,
+    AckSubtaskResultsVerifyFactory, SubtaskResultsSettledFactory,
     ForceGetTaskResultFactory, ForceGetTaskResultAckFactory,
     ForceGetTaskResultFailedFactory, ForceGetTaskResultRejectedFactory,
     ForceGetTaskResultUploadFactory, FileTransferToken,
@@ -381,35 +381,36 @@ class MessagesTestCase(unittest.TestCase):
 class ConcentsTest(unittest.TestCase):
 
     def test_subtask_result_verify(self):
-        srr = SubtaskResultRejectedFactory()
-        msg = SubtaskResultVerifyFactory(slots__subtask_result_rejected=srr)
+        srr = SubtaskResultsRejectedFactory()
+        msg = SubtaskResultsVerifyFactory(slots__subtask_result_rejected=srr)
         expected = [
             ['subtask_result_rejected', srr]
         ]
 
         self.assertEqual(expected, msg.slots())
         self.assertIsInstance(msg.subtask_result_rejected,
-                              message.tasks.SubtaskResultRejected)
+                              message.tasks.SubtaskResultsRejected)
 
     def test_ack_subtask_result_verify(self):
-        srv = SubtaskResultVerifyFactory()
-        msg = AckSubtaskResultVerifyFactory(slots__subtask_results_verify=srv)
+        srv = SubtaskResultsVerifyFactory()
+        msg = AckSubtaskResultsVerifyFactory(slots__subtask_results_verify=srv)
         expected = [
             ['subtask_result_verify', srv]
         ]
 
         self.assertEqual(expected, msg.slots())
         self.assertIsInstance(msg.subtask_result_verify,
-                              concents.SubtaskResultVerify)
+                              concents.SubtaskResultsVerify)
 
     def test_subtask_result_settled_no_acceptance(self):
         ttc = TaskToComputeFactory()
-        msg = SubtaskResultSettledFactory.origin_acceptance_timeout(
+        msg = SubtaskResultsSettledFactory.origin_acceptance_timeout(
             slots__task_to_compute=ttc
         )
         expected = [
             ['origin',
-             concents.SubtaskResultSettled.Origin.ResultsAcceptedTimeout.value],
+             concents.SubtaskResultsSettled.Origin.ResultsAcceptedTimeout
+             .value],
             ['task_to_compute', ttc]
         ]
 
@@ -418,12 +419,12 @@ class ConcentsTest(unittest.TestCase):
 
     def test_subtask_result_settled_results_rejected(self):
         ttc = TaskToComputeFactory()
-        msg = SubtaskResultSettledFactory.origin_results_rejected(
+        msg = SubtaskResultsSettledFactory.origin_results_rejected(
             slots__task_to_compute=ttc
         )
         expected = [
             ['origin',
-             concents.SubtaskResultSettled.Origin.ResultsRejected.value],
+             concents.SubtaskResultsSettled.Origin.ResultsRejected.value],
             ['task_to_compute', ttc]
         ]
 


### PR DESCRIPTION
Update names according to documentation and other `Message` classes naming
practice.

fixes: #96