### PR TITLE
- `ForceGetTaskResultsRejected.REASON.OperationAlreadyInitiated`

### DIFF
--- a/golem_messages/message/concents.py
+++ b/golem_messages/message/concents.py
@@ -296,7 +296,6 @@ class ForceGetTaskResultRejected(base.AbstractReasonMessage):
     ] + base.AbstractReasonMessage.__slots__
 
     class REASON(enum.Enum):
-        OperationAlreadyInitiated = 'operation_already_initiated'
         AcceptanceTimeLimitExceeded = 'acceptance_time_limit_exceeded'
 
     def deserialize_slot(self, key, value):


### PR DESCRIPTION
removing `ForceGetTaskResultsRejected.REASON.OperationAlreadyInitiated` as it has been deprecated in favor of a more generic `ServiceRefused.REASON.DuplicateRequest` response

closes #120 