### PR TITLE
Don't duplicate in ComputeTaskDef parameters from TaskHeader

### DIFF
--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -4,7 +4,6 @@ import functools
 from ethereum.utils import sha3
 
 from golem_messages import datastructures
-from golem_messages import exceptions
 from golem_messages import validators
 
 from . import base
@@ -24,15 +23,8 @@ class ComputeTaskDef(datastructures.FrozenDict):
         'src_code': '',
         'extra_data': {},  # safe because of copy in parent.__missing__()
         'short_description': '',
-        'return_address': '',
-        'return_port': 0,
-        # task_owner is a dict from golem.network.p2p.node.Node.to_dict()
-        # - requestor
-        'task_owner': None,
-        'key_id': 0,
         'working_directory': '',
         'performance': 0,
-        'environment': '',
         'docker_images': None,
     }
 
@@ -104,23 +96,6 @@ class TaskToCompute(base.Message):
         return '0x{}'.format(
             sha3(self.provider_ethereum_public_key)[12:].hex(),
         )
-
-    def load_slots(self, slots):
-        super().load_slots(slots)
-        self.validate_compute_task_def(self.compute_task_def)
-
-    def validate_compute_task_def(self, value):
-        try:
-            node_key = value['task_owner']['key']
-        except (TypeError, KeyError):
-            return
-        if node_key != self.requestor_id:
-            errmsg = "requestor_id: {} != compute_task_def['task_owner']['key']"
-            raise exceptions.FieldError(
-                errmsg.format(self.requestor_id, node_key),
-                field='compute_task_def',
-                value=value,
-            )
 
     def deserialize_slot(self, key, value):
         value = super().deserialize_slot(key, value)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -22,7 +22,6 @@ class ComputeTaskDefFactory(factory.DictFactory):
     class Meta:
         model = tasks.ComputeTaskDef
 
-    task_owner = factory.SubFactory(TaskOwnerFactory)
     task_id = factory.Faker('uuid4')
     subtask_id = factory.Faker('uuid4')
 
@@ -43,21 +42,6 @@ class TaskToComputeFactory(factory.Factory):
     provider_ethereum_public_key = factory.Faker('binary', length=64)
 
     compute_task_def = factory.SubFactory(ComputeTaskDefFactory)
-
-    @classmethod
-    def _create(cls, *args, **kwargs):
-        # ensure the `requestor_id` is the same as `task_owner['key']`
-        # unless they're explicitly set
-        if 'requestor_id' in kwargs and 'compute_task_def' not in kwargs:
-            kwargs['compute_task_def'] = ComputeTaskDefFactory(
-                task_owner__key=kwargs['requestor_id']
-            )
-        else:
-            task_def = kwargs.setdefault('compute_task_def',
-                                         ComputeTaskDefFactory())
-            kwargs['requestor_id'] = task_def.get('task_owner').get('key')
-
-        return super()._create(*args, **kwargs)
 
 
 class SubtaskResultsAcceptedFactory(factory.Factory):

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -89,27 +89,6 @@ class TaskToComputeTest(unittest.TestCase,
         msg = shortcuts.load(serialized, None, None)
         self.assertIsInstance(msg, message.tasks.TaskToCompute)
 
-    def test_task_to_compute_validate_compute_task_def(self):
-        requestor_id = 'such as epidemiology'
-        # Shoudn't raise
-        message.TaskToCompute(slots=(
-            ('requestor_id', requestor_id),
-        ))
-
-        compute_task_def = message.ComputeTaskDef(
-            task_owner={'key': requestor_id}
-        )
-        message.TaskToCompute(slots=(
-            ('requestor_id', requestor_id),
-            ('compute_task_def', compute_task_def),
-        ))
-
-        with self.assertRaises(exceptions.FieldError):
-            message.TaskToCompute(slots=(
-                ('requestor_id', 'staple of research'),
-                ('compute_task_def', compute_task_def),
-            ))
-
     def test_concent_enabled_attribute(self):
         ttc = factories.TaskToComputeFactory(concent_enabled=True)
         self.assertTrue(ttc.concent_enabled)


### PR DESCRIPTION
Removed fields:
  * `return_address`
  * `return_port`
  * `task_owner`
  * `key_id`
  * `environment`

Related issue: https://github.com/golemfactory/golem/issues/2073