### PR TITLE
move message timeout constants / helpers to `golem-messages` 

### DIFF
--- a/golem_messages/constants.py
+++ b/golem_messages/constants.py
@@ -1,0 +1,37 @@
+import collections
+import datetime
+
+from golem_messages import message
+
+# Maximum Message Transport Time, maximum transport time
+# allowed for transmission of a small message (if ping time is
+# greater than this, it means the communication is lagged).
+MMTT = datetime.timedelta(minutes=0, seconds=5)
+
+# Maximum Time Difference, maximum time difference from actual
+# time. (Time synchronisation)
+MTD = datetime.timedelta(minutes=0, seconds=10)
+
+# Maximum Action Time, maximum time needed to perform simple
+# machine operation.
+MAT = datetime.timedelta(minutes=2, seconds=15)
+
+# the download timeout margin independent from the size of the result
+DOWNLOAD_LEADIN_TIME = datetime.timedelta(minutes=1)
+
+# the assumed default resource download rate
+DEFAULT_UPLOAD_RATE = int(384 / 8)  # KB/s = kbps / 8
+
+DEFAULT_MSG_LIFETIME = (3 * MMTT + 3 * MAT)
+
+# Time to wait before sending a message
+MSG_DELAYS = collections.defaultdict(
+    lambda: datetime.timedelta(0),
+    {
+        message.ForceReportComputedTask: (2 * MMTT + MAT),
+    },
+)
+
+# A valid period of time for sending a message
+MSG_LIFETIMES = {
+}

--- a/golem_messages/helpers.py
+++ b/golem_messages/helpers.py
@@ -3,6 +3,7 @@ import math
 
 from .constants import DEFAULT_UPLOAD_RATE, DOWNLOAD_LEADIN_TIME
 
+
 def maximum_download_time(
         size: int, rate: int = DEFAULT_UPLOAD_RATE) -> datetime.timedelta:
     """

--- a/golem_messages/helpers.py
+++ b/golem_messages/helpers.py
@@ -1,0 +1,23 @@
+import datetime
+import math
+
+from .constants import DEFAULT_UPLOAD_RATE, DOWNLOAD_LEADIN_TIME
+
+def maximum_download_time(
+        size: int, rate: int = DEFAULT_UPLOAD_RATE) -> datetime.timedelta:
+    """
+    the maximum time (expressed as a timedelta) allowed for upload/download
+    of a resource of a given size between peers or between a Golem node and
+    the Concent.
+
+    :param size: size of payload in bytes
+    :param rate: transfer rate in KB/s
+    :return: the maxium
+    """
+
+    bytes_per_sec = rate << 10
+    download_time = datetime.timedelta(
+        seconds=int(math.ceil(size / bytes_per_sec))
+    )
+
+    return DOWNLOAD_LEADIN_TIME + download_time

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from golem_messages.constants import DEFAULT_UPLOAD_RATE, DOWNLOAD_LEADIN_TIME
 from golem_messages.helpers import maximum_download_time
 
+
 class MaximumDownloadTimeTest(TestCase):
     def test_maximum_download_time(self):
         secs = 100
@@ -12,7 +13,7 @@ class MaximumDownloadTimeTest(TestCase):
         self.assertEqual(expected, maximum_download_time(size))
 
     def test_maximum_download_time_w_rate(self):
-        size = 10240 << 10 # 10M
-        rate = 1024 # KB/s
+        size = 10240 << 10  # 10M
+        rate = 1024  # KB/s
         expected = timedelta(seconds=10) + DOWNLOAD_LEADIN_TIME
         self.assertEqual(expected, maximum_download_time(size, rate))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+from unittest import TestCase
+
+from golem_messages.constants import DEFAULT_UPLOAD_RATE, DOWNLOAD_LEADIN_TIME
+from golem_messages.helpers import maximum_download_time
+
+class MaximumDownloadTimeTest(TestCase):
+    def test_maximum_download_time(self):
+        secs = 100
+        size = secs * (DEFAULT_UPLOAD_RATE << 10)
+        expected = timedelta(seconds=secs) + DOWNLOAD_LEADIN_TIME
+        self.assertEqual(expected, maximum_download_time(size))
+
+    def test_maximum_download_time_w_rate(self):
+        size = 10240 << 10 # 10M
+        rate = 1024 # KB/s
+        expected = timedelta(seconds=10) + DOWNLOAD_LEADIN_TIME
+        self.assertEqual(expected, maximum_download_time(size, rate))


### PR DESCRIPTION
since they are effectively part of the communication protocol and thus also need to be shared between
Golem and the Concent