### PR TITLE
rm `GetTaskResult`, `TaskResultHash`

### DIFF
--- a/golem_messages/message/__init__.py
+++ b/golem_messages/message/__init__.py
@@ -28,9 +28,7 @@ from golem_messages.message.tasks import CannotComputeTask  # noqa
 from golem_messages.message.tasks import TaskToCompute  # noqa
 from golem_messages.message.tasks import WantToComputeTask  # noqa
 from golem_messages.message.tasks import ReportComputedTask  # noqa
-from golem_messages.message.tasks import TaskResultHash  # noqa
 from golem_messages.message.tasks import TaskFailure  # noqa
-from golem_messages.message.tasks import GetTaskResult  # noqa
 from golem_messages.message.tasks import StartSessionResponse  # noqa
 from golem_messages.message.tasks import WaitingForResults  # noqa
 from golem_messages.message.tasks import DeltaParts  # noqa
@@ -102,9 +100,7 @@ def init_messages():
             tasks.TaskToCompute,
             tasks.WantToComputeTask,
             tasks.ReportComputedTask,
-            tasks.TaskResultHash,
             tasks.TaskFailure,
-            tasks.GetTaskResult,
             tasks.StartSessionResponse,
 
             tasks.WaitingForResults,

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -167,31 +167,14 @@ class ReportComputedTask(base.Message):
         'eth_account',
         'task_to_compute',
         'size',
-        'checksum',
+        'multihash',
+        'secret',
+        'options',
     ] + base.Message.__slots__
 
     @base.verify_slot('task_to_compute', TaskToCompute)
     def deserialize_slot(self, key, value):
         return super().deserialize_slot(key, value)
-
-
-class GetTaskResult(base.Message):
-    """Request task result"""
-    TYPE = TASK_MSG_BASE + 5
-
-    __slots__ = ['subtask_id'] + base.Message.__slots__
-
-
-class TaskResultHash(base.Message):
-    TYPE = TASK_MSG_BASE + 7
-
-    __slots__ = [
-        'subtask_id',
-        'multihash',
-        'secret',
-        'options'
-    ] + base.Message.__slots__
-
 
 class GetResource(base.Message):
     """Request a resource for a given task"""

--- a/tests/message/test_messages.py
+++ b/tests/message/test_messages.py
@@ -183,7 +183,6 @@ class MessagesTestCase(unittest.TestCase):
         for message_class, key in (
                 (message.RemoveTask, 'task_id',),
                 (message.FindNode, 'node_key_id'),
-                (message.GetTaskResult, 'subtask_id'),
                 (message.StartSessionResponse, 'conn_id'),
                 (message.HasResource, 'resource'),
                 (message.WantsResource, 'resource'),


### PR DESCRIPTION
instead, all the necessary fields are included in the `ReportComputedTask`