### PR TITLE
Prevent accidental overwriting of message signature

### DIFF
--- a/golem_messages/exceptions.py
+++ b/golem_messages/exceptions.py
@@ -58,5 +58,9 @@ class SerializationError(MessageError):
     pass
 
 
+class SignatureAlreadyExists(SerializationError):
+    pass
+
+
 class VersionMismatchError(MessageError):
     pass

--- a/golem_messages/message/base.py
+++ b/golem_messages/message/base.py
@@ -297,6 +297,10 @@ class Message():
 
         if sign_func is None:
             sign_func = _fake_sign
+        elif self.sig is not None:
+            # If you wish to overwrite signature,
+            # first set it to None explicitly
+            raise exceptions.SignatureAlreadyExists()
 
         self.encrypted = bool(self.ENCRYPT and encrypt_func)
         payload = serializer.dumps(self.slots())

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,10 +2,9 @@ import time
 import uuid
 import random
 
+from ethereum.utils import denoms
 import factory
 import faker
-
-from ethereum.utils import denoms
 
 from golem_messages.message import concents
 from golem_messages.message import tasks


### PR DESCRIPTION
In fact this commit prevents a scenario where a signature
is silently not generated, when provided a signing key
as described in #162 

fixes: #162 