### PR TITLE
make the source of `subtask_id` and `task_id` information more explicit

### DIFF
--- a/golem_messages/message/__init__.py
+++ b/golem_messages/message/__init__.py
@@ -140,6 +140,7 @@ def init_messages():
             concents.ForceGetTaskResultFailed,
             concents.ForceGetTaskResultRejected,
             concents.ForceGetTaskResultUpload,
+            concents.ForceGetTaskResultDownload,
             concents.ForceSubtaskResults,
             concents.ForceSubtaskResultsResponse,
             concents.ForceSubtaskResultsRejected,

--- a/golem_messages/message/concents.py
+++ b/golem_messages/message/concents.py
@@ -33,6 +33,7 @@ class ServiceRefused(tasks.TaskMessageMixin, base.AbstractReasonMessage):
         ConcentDisabled = 'CONCENT_SERVICE_IS_NOT_ENABLED_FOR_THIS_SUBTASK'
 
     __slots__ = [
+        # @todo `subtask_id` is superfluous here
         'subtask_id',
         'task_to_compute',
     ] + base.AbstractReasonMessage.__slots__
@@ -78,6 +79,7 @@ class AckReportComputedTask(tasks.TaskMessageMixin, base.Message):
     TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
+        # @todo `subtask_id` is superfluous here
         'subtask_id',
         'task_to_compute',
     ] + base.Message.__slots__
@@ -116,6 +118,7 @@ class RejectReportComputedTask(tasks.TaskMessageMixin,
         GotMessageTaskFailure = 'GOT_MESSAGE_TASK_FAILURE'
 
     __slots__ = [
+        # @todo `subtask_id` is superfluous here
         'subtask_id',
         'task_to_compute',
         'task_failure',

--- a/golem_messages/message/concents.py
+++ b/golem_messages/message/concents.py
@@ -9,7 +9,7 @@ from . import tasks
 CONCENT_MSG_BASE = 4000
 
 
-class ServiceRefused(base.AbstractReasonMessage):
+class ServiceRefused(tasks.TaskMessageMixin, base.AbstractReasonMessage):
     """
     Sent (synchronously) as a response from the Concent to the calling party
     (either a Provider or a Requestor), informing them that the Concent refuses
@@ -20,6 +20,7 @@ class ServiceRefused(base.AbstractReasonMessage):
     :param REASON reason: the reason for the refusal
     """
     TYPE = CONCENT_MSG_BASE
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     @enum.unique
     class REASON(enum.Enum):
@@ -41,7 +42,7 @@ class ServiceRefused(base.AbstractReasonMessage):
         return super().deserialize_slot(key, value)
 
 
-class ForceReportComputedTask(base.Message):
+class ForceReportComputedTask(tasks.TaskMessageMixin, base.Message):
     """
     Message sent from a Provider to the Concent, requesting an forced
     acknowledgment of the reception of the `ReportComputedTask` message
@@ -50,6 +51,7 @@ class ForceReportComputedTask(base.Message):
     The same, rewritten message is then sent from the Concent to the Requestor.
     """
     TYPE = CONCENT_MSG_BASE + 1
+    TASK_ID_PROVIDERS = ('report_computed_task', )
 
     __slots__ = [
         'report_computed_task',
@@ -61,7 +63,7 @@ class ForceReportComputedTask(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class AckReportComputedTask(base.Message):
+class AckReportComputedTask(tasks.TaskMessageMixin, base.Message):
     """
     Sent from Requestor to the Provider, acknowledging reception of the
     `ReportComputedTask` message.
@@ -73,6 +75,7 @@ class AckReportComputedTask(base.Message):
     """
 
     TYPE = CONCENT_MSG_BASE + 2
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
         'subtask_id',
@@ -84,8 +87,12 @@ class AckReportComputedTask(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class RejectReportComputedTask(base.AbstractReasonMessage):
+class RejectReportComputedTask(tasks.TaskMessageMixin,
+                               base.AbstractReasonMessage):
     TYPE = CONCENT_MSG_BASE + 3
+    TASK_ID_PROVIDERS = ('task_to_compute',
+                         'task_failure',
+                         'cannot_compute_task', )
 
     @enum.unique
     class REASON(enum.Enum):
@@ -122,7 +129,7 @@ class RejectReportComputedTask(base.AbstractReasonMessage):
         return super().deserialize_slot(key, value)
 
 
-class VerdictReportComputedTask(base.Message):
+class VerdictReportComputedTask(tasks.TaskMessageMixin, base.Message):
     """
     Informational message sent from from the Concent to the affected
     Requestor, informing them that the `ReportComputedTask` has been implicitly
@@ -133,6 +140,8 @@ class VerdictReportComputedTask(base.Message):
     as if the Requestor sent the `AckReportComputedTask` on their own.
     """
     TYPE = CONCENT_MSG_BASE + 4
+    TASK_ID_PROVIDERS = ('force_report_computed_task',
+                         'ack_report_computed_task', )
 
     __slots__ = [
         'force_report_computed_task',
@@ -176,7 +185,7 @@ class FileTransferToken(base.Message):
         }
 
 
-class SubtaskResultsVerify(base.Message):
+class SubtaskResultsVerify(tasks.TaskMessageMixin, base.Message):
     """
     Message sent from a Provider to the Concent, requesting additional
     verification in case the result had been rejected by the Requestor
@@ -186,6 +195,7 @@ class SubtaskResultsVerify(base.Message):
 
     """
     TYPE = CONCENT_MSG_BASE + 6
+    TASK_ID_PROVIDERS = ('subtask_results_rejected', )
 
     __slots__ = [
         'subtask_results_rejected',
@@ -196,7 +206,7 @@ class SubtaskResultsVerify(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class AckSubtaskResultsVerify(base.Message):
+class AckSubtaskResultsVerify(tasks.TaskMessageMixin, base.Message):
     """
     Message sent from the Concent to the Provider to acknowledge reception
     of the `SubtaskResultsVerify` message and more importantly, to pass the
@@ -204,6 +214,7 @@ class AckSubtaskResultsVerify(base.Message):
     to upload files to the Concent service.
     """
     TYPE = CONCENT_MSG_BASE + 7
+    TASK_ID_PROVIDERS = ('subtask_results_verify', )
 
     __slots__ = [
         'subtask_results_verify',
@@ -216,7 +227,7 @@ class AckSubtaskResultsVerify(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class SubtaskResultsSettled(base.Message):
+class SubtaskResultsSettled(tasks.TaskMessageMixin, base.Message):
     """
     Message sent from the Concent to both the Provider and the Requestor
     informing of positive acceptance of the results by the Concent and the
@@ -232,6 +243,7 @@ class SubtaskResultsSettled(base.Message):
     """
 
     TYPE = CONCENT_MSG_BASE + 8
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     @enum.unique
     class Origin(enum.Enum):
@@ -252,8 +264,9 @@ class SubtaskResultsSettled(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResult(base.Message):
+class ForceGetTaskResult(tasks.TaskMessageMixin, base.Message):
     TYPE = CONCENT_MSG_BASE + 9
+    TASK_ID_PROVIDERS = ('report_computed_task', )
 
     __slots__ = [
         'report_computed_task',
@@ -264,8 +277,9 @@ class ForceGetTaskResult(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class AckForceGetTaskResult(base.Message):
+class AckForceGetTaskResult(tasks.TaskMessageMixin, base.Message):
     TYPE = CONCENT_MSG_BASE + 10
+    TASK_ID_PROVIDERS = ('force_get_task_result', )
 
     __slots__ = [
         'force_get_task_result',
@@ -276,8 +290,17 @@ class AckForceGetTaskResult(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultFailed(base.Message):
+class ForceGetTaskResultFailed(tasks.TaskMessageMixin, base.Message):
+    """
+    Sent from the Concent to the Requestor to announce a failure to retrieve
+    the results from the Provider.
+
+    Having received this message, the Requestor can use it later on
+    to reject any attempt at forced acceptance by proving the result
+    could not have been downloaded in the first place.
+    """
     TYPE = CONCENT_MSG_BASE + 11
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
         'task_to_compute',
@@ -288,8 +311,10 @@ class ForceGetTaskResultFailed(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultRejected(base.AbstractReasonMessage):
+class ForceGetTaskResultRejected(tasks.TaskMessageMixin,
+                                 base.AbstractReasonMessage):
     TYPE = CONCENT_MSG_BASE + 12
+    TASK_ID_PROVIDERS = ('force_get_task_result', )
 
     __slots__ = [
         'force_get_task_result',
@@ -303,8 +328,9 @@ class ForceGetTaskResultRejected(base.AbstractReasonMessage):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultUpload(base.Message):
+class ForceGetTaskResultUpload(tasks.TaskMessageMixin, base.Message):
     TYPE = CONCENT_MSG_BASE + 13
+    TASK_ID_PROVIDERS = ('force_get_task_result', )
 
     __slots__ = [
         'force_get_task_result',
@@ -317,8 +343,9 @@ class ForceGetTaskResultUpload(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultDownload(base.Message):
+class ForceGetTaskResultDownload(tasks.TaskMessageMixin, base.Message):
     TYPE = CONCENT_MSG_BASE + 14
+    TASK_ID_PROVIDERS = ('force_get_task_result', )
 
     __slots__ = [
         'force_get_task_result',
@@ -331,7 +358,7 @@ class ForceGetTaskResultDownload(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceSubtaskResults(base.Message):
+class ForceSubtaskResults(tasks.TaskMessageMixin, base.Message):
     """
     Sent from the Provider to the Concent, in an effort to force the
     `SubtaskResultsAccepted/Rejected` message from the Requestor
@@ -343,6 +370,7 @@ class ForceSubtaskResults(base.Message):
                                                            of the RCT message
     """
     TYPE = CONCENT_MSG_BASE + 15
+    TASK_ID_PROVIDERS = ('ack_report_computed_task', )
 
     __slots__ = [
         'ack_report_computed_task',
@@ -353,7 +381,7 @@ class ForceSubtaskResults(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceSubtaskResultsResponse(base.Message):
+class ForceSubtaskResultsResponse(tasks.TaskMessageMixin, base.Message):
     """
     Sent from the Concent to the Provider to communicate the final resolution
     of the forced results verdict.
@@ -364,6 +392,8 @@ class ForceSubtaskResultsResponse(base.Message):
     :param SubtaskResultsRejected subtask_results_rejected:
     """
     TYPE = CONCENT_MSG_BASE + 16
+    TASK_ID_PROVIDERS = ('subtask_results_accepted',
+                         'subtask_results_rejected', )
 
     __slots__ = [
         'subtask_results_accepted',
@@ -473,10 +503,13 @@ class ForcePaymentRejected(base.AbstractReasonMessage):
         return super().deserialize_slot(key, value)
 
 
-class ForceReportComputedTaskResponse(base.AbstractReasonMessage):
+class ForceReportComputedTaskResponse(tasks.TaskMessageMixin,
+                                      base.AbstractReasonMessage):
     """Sent from Concent to Provider as a response to ForceReportComputedTask.
     """
     TYPE = CONCENT_MSG_BASE + 21
+    TASK_ID_PROVIDERS = ('ack_report_computed_task',
+                         'reject_report_computed_task', )
 
     @enum.unique
     class REASON(enum.Enum):

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -50,21 +50,23 @@ class TaskMessageMixin():
     __slots__ = []
     TASK_ID_PROVIDERS = ()
 
-    @property
-    def task_id(self):
-        msgs = [slot for slot in self.TASK_ID_PROVIDERS if hasattr(self, slot)]
+    def _get_task_value(self, attr_name):
+        msgs = [getattr(self, slot)
+                for slot in self.TASK_ID_PROVIDERS
+                if hasattr(self, slot)]
+
         for msg in msgs:
-            if hasattr(msg, 'task_id'):
-                return msg.task_id
+            if hasattr(msg, attr_name):
+                return getattr(msg, attr_name)
         return None
 
     @property
+    def task_id(self):
+        return self._get_task_value('task_id')
+
+    @property
     def subtask_id(self):
-        msgs = [slot for slot in self.TASK_ID_PROVIDERS if hasattr(self, slot)]
-        for msg in msgs:
-            if hasattr(msg, 'subtask_id'):
-                return msg.subtask_id
-        return None
+        return self._get_task_value('subtask_id')
 
 
 class WantToComputeTask(base.Message):
@@ -163,6 +165,8 @@ class ReportComputedTask(TaskMessageMixin, base.Message):
     TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
+        # @todo I'd remove the `subtask_id` from here as it's
+        # present within `task_to_compute` anyway...
         'subtask_id',
         # TODO why do we need the type here?
         'result_type',

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -46,6 +46,26 @@ class ComputeTaskDef(datastructures.FrozenDict):
         max_length=128,
     )
 
+class TaskMessageMixin():
+    __slots__ = []
+    TASK_ID_PROVIDERS = ()
+
+    @property
+    def task_id(self):
+        msgs = [slot for slot in self.TASK_ID_PROVIDERS if hasattr(self, slot)]
+        for msg in msgs:
+            if hasattr(msg, 'task_id'):
+                return msg.task_id
+        return None
+
+    @property
+    def subtask_id(self):
+        msgs = [slot for slot in self.TASK_ID_PROVIDERS if hasattr(self, slot)]
+        for msg in msgs:
+            if hasattr(msg, 'subtask_id'):
+                return msg.subtask_id
+        return None
+
 
 class WantToComputeTask(base.Message):
     TYPE = TASK_MSG_BASE + 1
@@ -61,7 +81,7 @@ class WantToComputeTask(base.Message):
     ] + base.Message.__slots__
 
 
-class TaskToCompute(base.Message):
+class TaskToCompute(TaskMessageMixin, base.Message):
     TYPE = TASK_MSG_BASE + 2
 
     __slots__ = [
@@ -103,6 +123,18 @@ class TaskToCompute(base.Message):
             value = ComputeTaskDef(value)
         return value
 
+    @property
+    def task_id(self):
+        if self.compute_task_def:
+            return self.compute_task_def.get('task_id')
+        return None
+
+    @property
+    def subtask_id(self):
+        if self.compute_task_def:
+            return self.compute_task_def.get('subtask_id')
+        return None
+
 
 class CannotAssignTask(base.AbstractReasonMessage):
     TYPE = TASK_MSG_BASE + 3
@@ -116,7 +148,7 @@ class CannotAssignTask(base.AbstractReasonMessage):
         NoMoreSubtasks = 'no_more_subtasks'
 
 
-class ReportComputedTask(base.Message):
+class ReportComputedTask(TaskMessageMixin, base.Message):
     """
     Message sent from a Provider to a Requestor, announcing completion
     of the assigned subtask (attached as `task_to_compute`)
@@ -127,6 +159,8 @@ class ReportComputedTask(base.Message):
         'DATA': 0,
         'FILES': 1,
     }
+
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
         'subtask_id',
@@ -153,6 +187,7 @@ class ReportComputedTask(base.Message):
     def deserialize_slot(self, key, value):
         return super().deserialize_slot(key, value)
 
+
 class GetResource(base.Message):
     """Request a resource for a given task"""
     TYPE = TASK_MSG_BASE + 8
@@ -163,7 +198,7 @@ class GetResource(base.Message):
     ] + base.Message.__slots__
 
 
-class SubtaskResultsAccepted(base.Message):
+class SubtaskResultsAccepted(TaskMessageMixin, base.Message):
     """
     Sent from the Requestor to the Provider, accepting the provider's
     completed task results.
@@ -171,6 +206,7 @@ class SubtaskResultsAccepted(base.Message):
     Having received this message, the Provider expects payment to follow.
     """
     TYPE = TASK_MSG_BASE + 10
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
         'payment_ts',
@@ -182,7 +218,7 @@ class SubtaskResultsAccepted(base.Message):
         return super().deserialize_slot(key, value)
 
 
-class SubtaskResultsRejected(base.AbstractReasonMessage):
+class SubtaskResultsRejected(TaskMessageMixin, base.AbstractReasonMessage):
     """
     Sent from the Requestor to the Provider, rejecting the provider's
     completed task results
@@ -195,6 +231,7 @@ class SubtaskResultsRejected(base.AbstractReasonMessage):
     results could not have been retrieved.)
     """
     TYPE = TASK_MSG_BASE + 11
+    TASK_ID_PROVIDERS = ('report_computed_task', )
 
     __slots__ = [
         'report_computed_task',
@@ -214,7 +251,6 @@ class SubtaskResultsRejected(base.AbstractReasonMessage):
     @base.verify_slot('report_computed_task', ReportComputedTask)
     def deserialize_slot(self, key, value):
         return super().deserialize_slot(key, value)
-
 
 class DeltaParts(base.Message):
     """base.Message with resource description in form of "delta parts".
@@ -243,8 +279,9 @@ class DeltaParts(base.Message):
     ] + base.Message.__slots__
 
 
-class TaskFailure(base.Message):
+class TaskFailure(TaskMessageMixin, base.Message):
     TYPE = TASK_MSG_BASE + 15
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
         'subtask_id',
@@ -279,6 +316,7 @@ class WaitingForResults(base.Message):
 
 class CannotComputeTask(base.AbstractReasonMessage):
     TYPE = TASK_MSG_BASE + 26
+    TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
         'subtask_id',

--- a/tests/message/mixins.py
+++ b/tests/message/mixins.py
@@ -15,6 +15,7 @@ class RegisteredMessageTestMixin():
 
 
 class SerializationMixin():
+
     def get_instance(self):
         return self.FACTORY()
 
@@ -23,3 +24,36 @@ class SerializationMixin():
         s_msg = golem_messages.dump(msg, None, None)
         msg2 = golem_messages.load(s_msg, None, None)
         self.assertEqual(msg, msg2)
+
+class TaskIdMixinBase():
+    TASK_ID_PROVIDER = None
+
+    @property
+    def task_id_provider(self):
+        return getattr(self.msg, self.TASK_ID_PROVIDER)
+
+    def setUp(self):
+        self.msg = self.FACTORY()
+
+    def test_task_id(self):
+        self.assertEqual(self.msg.task_id, self.task_id_provider.task_id)
+
+    def test_subtask_id(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.task_id_provider.subtask_id)
+
+
+class TaskIdTaskToComputeTestMixin(TaskIdMixinBase):
+    TASK_ID_PROVIDER = 'task_to_compute'
+
+
+class TaskIdReportComputedTaskTestMixin(TaskIdMixinBase):
+    TASK_ID_PROVIDER = 'report_computed_task'
+
+
+class TaskIdForceGetTaskResultTestMixin(TaskIdMixinBase):
+    TASK_ID_PROVIDER = 'force_get_task_result'
+
+
+class TaskIdAckReportComputedTaskTestMixin(TaskIdMixinBase):
+    TASK_ID_PROVIDER = 'ack_report_computed_task'

--- a/tests/message/test_concents.py
+++ b/tests/message/test_concents.py
@@ -6,17 +6,28 @@ from golem_messages import message
 from golem_messages.message import concents
 
 from tests import factories
+from tests.message import mixins
 
-from .mixins import RegisteredMessageTestMixin
-from .mixins import SerializationMixin
+class ServiceRefusedTest(mixins.RegisteredMessageTestMixin,
+                         mixins.SerializationMixin,
+                         mixins.TaskIdTaskToComputeTestMixin,
+                         unittest.TestCase):
+    FACTORY = factories.ServiceRefusedFactory
+    MSG_CLASS = concents.ServiceRefused
 
 
-class SubtaskResultsVerifyTest(RegisteredMessageTestMixin, unittest.TestCase):
+class SubtaskResultsVerifyTest(mixins.RegisteredMessageTestMixin,
+                               mixins.SerializationMixin,
+                               unittest.TestCase):
+    FACTORY = factories.SubtaskResultsVerifyFactory
     MSG_CLASS = concents.SubtaskResultsVerify
+
+    def setUp(self):
+        self.msg = self.FACTORY()
 
     def test_subtask_results_verify(self):
         srr = factories.SubtaskResultsRejectedFactory()
-        msg = factories.SubtaskResultsVerifyFactory(
+        msg = self.FACTORY(
             subtask_results_rejected=srr,
         )
         expected = [
@@ -27,10 +38,28 @@ class SubtaskResultsVerifyTest(RegisteredMessageTestMixin, unittest.TestCase):
         self.assertIsInstance(msg.subtask_results_rejected,
                               message.tasks.SubtaskResultsRejected)
 
+    def test_task_id(self):
+        self.assertEqual(self.msg.task_id,
+                         self.msg.subtask_results_rejected.task_id)
+
+    def test_subtask_id(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.subtask_results_rejected.subtask_id)
+
+
+class AckSubtaskResultsVerifyTest(mixins.RegisteredMessageTestMixin,
+                                  mixins.SerializationMixin,
+                                  unittest.TestCase):
+    FACTORY = factories.AckSubtaskResultsVerifyFactory
+    MSG_CLASS = concents.AckSubtaskResultsVerify
+
+    def setUp(self):
+        self.msg = self.FACTORY()
+
     def test_ack_subtask_results_verify(self):
         srv = factories.SubtaskResultsVerifyFactory()
         ftt = factories.FileTransferTokenFactory()
-        msg = factories.AckSubtaskResultsVerifyFactory(
+        msg = self.FACTORY(
             subtask_results_verify=srv,
             file_transfer_token=ftt,
         )
@@ -45,8 +74,20 @@ class SubtaskResultsVerifyTest(RegisteredMessageTestMixin, unittest.TestCase):
         self.assertIsInstance(msg.file_transfer_token,
                               concents.FileTransferToken)
 
+    def test_task_id(self):
+        self.assertEqual(self.msg.task_id,
+                         self.msg.subtask_results_verify.task_id)
 
-class SubtaskResultsSettledTest(RegisteredMessageTestMixin, unittest.TestCase):
+    def test_subtask_id(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.subtask_results_verify.subtask_id)
+
+
+class SubtaskResultsSettledTest(mixins.RegisteredMessageTestMixin,
+                                mixins.SerializationMixin,
+                                mixins.TaskIdTaskToComputeTestMixin,
+                                unittest.TestCase):
+    FACTORY = factories.SubtaskResultsSettledFactory
     MSG_CLASS = concents.SubtaskResultsSettled
 
     def test_subtask_result_settled_no_acceptance(self):
@@ -79,11 +120,16 @@ class SubtaskResultsSettledTest(RegisteredMessageTestMixin, unittest.TestCase):
         self.assertIsInstance(msg.task_to_compute, message.tasks.TaskToCompute)
 
 
-class ConcentsTest(unittest.TestCase):
+class ForceGetTaskResultTest(mixins.RegisteredMessageTestMixin,
+                             mixins.SerializationMixin,
+                             mixins.TaskIdReportComputedTaskTestMixin,
+                             unittest.TestCase):
+    FACTORY = factories.ForceGetTaskResultFactory
+    MSG_CLASS = message.concents.ForceGetTaskResult
 
     def test_force_get_task_result(self):
         rct = factories.ReportComputedTaskFactory()
-        msg = factories.ForceGetTaskResultFactory(
+        msg = self.FACTORY(
             report_computed_task=rct,
         )
         expected = [
@@ -93,6 +139,14 @@ class ConcentsTest(unittest.TestCase):
         self.assertEqual(expected, msg.slots())
         self.assertIsInstance(msg.report_computed_task,
                               message.tasks.ReportComputedTask)
+
+
+class AckForceGetTaskResultTest(mixins.RegisteredMessageTestMixin,
+                                mixins.SerializationMixin,
+                                mixins.TaskIdForceGetTaskResultTestMixin,
+                                unittest.TestCase):
+    FACTORY = factories.AckForceGetTaskResultFactory
+    MSG_CLASS = message.concents.AckForceGetTaskResult
 
     def test_ack_force_get_task_result(self):
         fgtr = factories.ForceGetTaskResultFactory()
@@ -107,6 +161,14 @@ class ConcentsTest(unittest.TestCase):
         self.assertIsInstance(msg.force_get_task_result,
                               message.concents.ForceGetTaskResult)
 
+
+class ForceGetTaskResultFailedTest(mixins.RegisteredMessageTestMixin,
+                                   mixins.SerializationMixin,
+                                   mixins.TaskIdTaskToComputeTestMixin,
+                                   unittest.TestCase):
+    FACTORY = factories.ForceGetTaskResultFailedFactory
+    MSG_CLASS = message.concents.ForceGetTaskResultFailed
+
     def test_force_get_task_result_failed(self):
         ttc = factories.TaskToComputeFactory()
         msg = factories.ForceGetTaskResultFailedFactory(
@@ -118,6 +180,14 @@ class ConcentsTest(unittest.TestCase):
 
         self.assertEqual(expected, msg.slots())
         self.assertIsInstance(msg.task_to_compute, message.tasks.TaskToCompute)
+
+
+class ForceGetTaskResultRejectedTest(mixins.RegisteredMessageTestMixin,
+                                     mixins.SerializationMixin,
+                                     mixins.TaskIdForceGetTaskResultTestMixin,
+                                     unittest.TestCase):
+    FACTORY = factories.ForceGetTaskResultRejectedFactory
+    MSG_CLASS = message.concents.ForceGetTaskResultRejected
 
     def test_force_get_task_result_rejected(self):
         fgtr = factories.ForceGetTaskResultFactory()
@@ -132,6 +202,14 @@ class ConcentsTest(unittest.TestCase):
         self.assertEqual(expected, msg.slots())
         self.assertIsInstance(msg.force_get_task_result,
                               message.concents.ForceGetTaskResult)
+
+
+class ForceGetTaskResultUploadTest(mixins.RegisteredMessageTestMixin,
+                                   mixins.SerializationMixin,
+                                   mixins.TaskIdForceGetTaskResultTestMixin,
+                                   unittest.TestCase):
+    FACTORY = factories.ForceGetTaskResultUploadFactory
+    MSG_CLASS = message.concents.ForceGetTaskResultUpload
 
     def test_force_get_task_result_upload(self):
         fgtr = factories.ForceGetTaskResultFactory()
@@ -150,6 +228,14 @@ class ConcentsTest(unittest.TestCase):
                               message.concents.ForceGetTaskResult)
         self.assertIsInstance(msg.file_transfer_token,
                               message.concents.FileTransferToken)
+
+
+class ForceGetTaskResultDownloadTest(mixins.RegisteredMessageTestMixin,
+                                     mixins.SerializationMixin,
+                                     mixins.TaskIdForceGetTaskResultTestMixin,
+                                     unittest.TestCase):
+    FACTORY = factories.ForceGetTaskResultDownloadFactory
+    MSG_CLASS = message.concents.ForceGetTaskResultDownload
 
     def test_force_get_task_result_download(self):
         fgtr = factories.ForceGetTaskResultFactory()
@@ -170,7 +256,11 @@ class ConcentsTest(unittest.TestCase):
                               message.concents.FileTransferToken)
 
 
-class ForceSubtaskResultsTest(RegisteredMessageTestMixin, unittest.TestCase):
+class ForceSubtaskResultsTest(mixins.RegisteredMessageTestMixin,
+                              mixins.SerializationMixin,
+                              mixins.TaskIdAckReportComputedTaskTestMixin,
+                              unittest.TestCase):
+    FACTORY = factories.ForceSubtaskResultsFactory
     MSG_CLASS = concents.ForceSubtaskResults
 
     def test_force_subtask_results(self):
@@ -189,8 +279,10 @@ class ForceSubtaskResultsTest(RegisteredMessageTestMixin, unittest.TestCase):
                               message.concents.AckReportComputedTask)
 
 
-class ForceSubtaskResultsResponseTest(RegisteredMessageTestMixin,
+class ForceSubtaskResultsResponseTest(mixins.RegisteredMessageTestMixin,
+                                      mixins.SerializationMixin,
                                       unittest.TestCase):
+    FACTORY = factories.ForceSubtaskResultsResponseFactory
     MSG_CLASS = concents.ForceSubtaskResultsResponse
 
     def test_force_subtask_results_response_accepted(self):
@@ -269,8 +361,28 @@ class ForceSubtaskResultsResponseTest(RegisteredMessageTestMixin,
                 ('subtask_results_rejected', 'phouchg'),
             ))
 
+    def test_task_id_srr(self):
+        msg = self.FACTORY.with_rejected()
+        self.assertEqual(msg.task_id,
+                         msg.subtask_results_rejected.task_id)
 
-class ForceSubtaskResultsRejectedTest(RegisteredMessageTestMixin,
+    def test_subtask_id_srr(self):
+        msg = self.FACTORY.with_rejected()
+        self.assertEqual(msg.subtask_id,
+                         msg.subtask_results_rejected.subtask_id)
+
+    def test_task_id_sra(self):
+        msg = self.FACTORY.with_accepted()
+        self.assertEqual(msg.task_id,
+                         msg.subtask_results_accepted.task_id)
+
+    def test_subtask_id_sra(self):
+        msg = self.FACTORY.with_accepted()
+        self.assertEqual(msg.subtask_id,
+                         msg.subtask_results_accepted.subtask_id)
+
+
+class ForceSubtaskResultsRejectedTest(mixins.RegisteredMessageTestMixin,
                                       unittest.TestCase):
     MSG_CLASS = concents.ForceSubtaskResultsRejected
 
@@ -289,7 +401,7 @@ class ForceSubtaskResultsRejectedTest(RegisteredMessageTestMixin,
         )
 
 
-class ForcePaymentTest(RegisteredMessageTestMixin, unittest.TestCase):
+class ForcePaymentTest(mixins.RegisteredMessageTestMixin, unittest.TestCase):
     MSG_CLASS = concents.ForcePayment
 
     def test_factory(self):
@@ -300,7 +412,7 @@ class ForcePaymentTest(RegisteredMessageTestMixin, unittest.TestCase):
         msg = factories.ForcePaymentFactory.with_accepted_tasks()
         self.assertIsInstance(msg.subtask_results_accepted_list, list)
         self.assertIsInstance(
-            msg.subtask_results_accepted_list[0], # noqa pylint:disable=unsubscriptable-object
+            msg.subtask_results_accepted_list[0],  # noqa pylint:disable=unsubscriptable-object
             message.tasks.SubtaskResultsAccepted)
 
     def test_factory_list_provided(self):
@@ -310,7 +422,7 @@ class ForcePaymentTest(RegisteredMessageTestMixin, unittest.TestCase):
             ])
         self.assertIsInstance(msg.subtask_results_accepted_list, list)
         self.assertIsInstance(
-            msg.subtask_results_accepted_list[0], # noqa pylint:disable=unsubscriptable-object
+            msg.subtask_results_accepted_list[0],  # noqa pylint:disable=unsubscriptable-object
             message.tasks.SubtaskResultsAccepted)
 
     def test_sra_list_verify(self):
@@ -329,7 +441,8 @@ class ForcePaymentTest(RegisteredMessageTestMixin, unittest.TestCase):
             ])
 
 
-class ForcePaymentCommittedTest(RegisteredMessageTestMixin, unittest.TestCase):
+class ForcePaymentCommittedTest(mixins.RegisteredMessageTestMixin,
+                                unittest.TestCase):
     MSG_CLASS = concents.ForcePaymentCommitted
 
     def test_factory(self):
@@ -347,7 +460,8 @@ class ForcePaymentCommittedTest(RegisteredMessageTestMixin, unittest.TestCase):
                          concents.ForcePaymentCommitted.Actor.Requestor)
 
 
-class ForcePaymentRejectedTest(RegisteredMessageTestMixin, unittest.TestCase):
+class ForcePaymentRejectedTest(mixins.RegisteredMessageTestMixin,
+                               unittest.TestCase):
     MSG_CLASS = concents.ForcePaymentRejected
 
     def test_factory(self):
@@ -366,17 +480,91 @@ class ForcePaymentRejectedTest(RegisteredMessageTestMixin, unittest.TestCase):
                 ('force_payment', message.base.Message())
             ])
 
+
+class ForceReportComputedTaskTestCase(
+        mixins.RegisteredMessageTestMixin,
+        mixins.TaskIdReportComputedTaskTestMixin,
+        mixins.SerializationMixin,
+        unittest.TestCase):
+    MSG_CLASS = concents.ForceReportComputedTask
+    FACTORY = factories.ForceReportComputedTaskFactory
+
+
 class ForceReportComputedTaskResponseTestCase(
-        RegisteredMessageTestMixin,
-        SerializationMixin,
+        mixins.RegisteredMessageTestMixin,
+        mixins.SerializationMixin,
         unittest.TestCase):
     MSG_CLASS = concents.ForceReportComputedTaskResponse
     FACTORY = factories.ForceReportComputedTaskResponseFactory
 
+    def setUp(self):
+        self.msg = self.FACTORY()
+
+    def test_task_id_ack(self):
+        self.assertEqual(self.msg.task_id,
+                         self.msg.ack_report_computed_task.task_id)
+
+    def test_subtask_id_ack(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.ack_report_computed_task.subtask_id)
+
+    def test_task_id_reject(self):
+        self.assertEqual(self.msg.task_id,
+                         self.msg.reject_report_computed_task.task_id)
+
+    def test_subtask_id_reject(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.reject_report_computed_task.subtask_id)
+
+
+class AckReportComputedTaskTestCase(
+        mixins.RegisteredMessageTestMixin,
+        mixins.TaskIdTaskToComputeTestMixin,
+        mixins.SerializationMixin,
+        unittest.TestCase):
+    MSG_CLASS = concents.AckReportComputedTask
+    FACTORY = factories.AckReportComputedTaskFactory
+
+
+class RejectReportComputedTaskTestCase(
+        mixins.RegisteredMessageTestMixin,
+        mixins.TaskIdTaskToComputeTestMixin,
+        mixins.SerializationMixin,
+        unittest.TestCase):
+    MSG_CLASS = concents.RejectReportComputedTask
+    FACTORY = factories.RejectReportComputedTaskFactory
+
+
+class VerdictReportComputeTaskTestCase(
+        mixins.RegisteredMessageTestMixin,
+        mixins.SerializationMixin,
+        unittest.TestCase):
+    MSG_CLASS = concents.VerdictReportComputedTask
+    FACTORY = factories.VerdictReportComputedTaskFactory
+
+    def setUp(self):
+        self.msg = self.FACTORY()
+
+    def test_task_id(self):
+        self.assertEqual(self.msg.task_id,
+                         self.msg.ack_report_computed_task.task_id)
+
+    def test_subtask_id(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.ack_report_computed_task.subtask_id)
+
+    def test_task_id_frct(self):
+        self.assertEqual(self.msg.task_id,
+                         self.msg.force_report_computed_task.task_id)
+
+    def test_subtask_id_frct(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.force_report_computed_task.subtask_id)
+
 
 class ClientAuthorizationTestCase(
-        RegisteredMessageTestMixin,
-        SerializationMixin,
+        mixins.RegisteredMessageTestMixin,
+        mixins.SerializationMixin,
         unittest.TestCase):
     MSG_CLASS = concents.ClientAuthorization
     FACTORY = factories.ClientAuthorizationFactory

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -7,10 +7,7 @@ from golem_messages import message
 from golem_messages import shortcuts
 
 from tests import factories
-
-from .mixins import RegisteredMessageTestMixin
-from .mixins import SerializationMixin
-
+from tests.message import mixins
 
 class ComputeTaskDefTestCase(unittest.TestCase):
     @mock.patch('golem_messages.message.tasks.ComputeTaskDef.validate_task_id')
@@ -30,13 +27,15 @@ class ComputeTaskDefTestCase(unittest.TestCase):
         )
 
 
-class SubtaskResultsAcceptedTest(RegisteredMessageTestMixin,
+class SubtaskResultsAcceptedTest(mixins.RegisteredMessageTestMixin,
+                                 mixins.SerializationMixin,
+                                 mixins.TaskIdTaskToComputeTestMixin,
                                  unittest.TestCase):
+    FACTORY = factories.SubtaskResultsAcceptedFactory
     MSG_CLASS = message.tasks.SubtaskResultsAccepted
 
     def test_factory(self):
-        msg = factories.SubtaskResultsAcceptedFactory()
-        self.assertIsInstance(msg, message.tasks.SubtaskResultsAccepted)
+        self.assertIsInstance(self.msg, message.tasks.SubtaskResultsAccepted)
 
     def test_task_to_compute_wrong_class(self):
         with self.assertRaises(exceptions.FieldError):
@@ -51,8 +50,11 @@ class SubtaskResultsAcceptedTest(RegisteredMessageTestMixin,
         self.assertIsInstance(msg.task_to_compute, message.tasks.TaskToCompute)
 
 
-class SubtaskResultsRejectedTest(RegisteredMessageTestMixin,
+class SubtaskResultsRejectedTest(mixins.RegisteredMessageTestMixin,
+                                 mixins.SerializationMixin,
+                                 mixins.TaskIdReportComputedTaskTestMixin,
                                  unittest.TestCase):
+    FACTORY = factories.SubtaskResultsRejectedFactory
     MSG_CLASS = message.tasks.SubtaskResultsRejected
 
     def test_subtask_results_rejected_factory(self):
@@ -77,11 +79,14 @@ class SubtaskResultsRejectedTest(RegisteredMessageTestMixin,
                               message.tasks.ReportComputedTask)
 
 
-class TaskToComputeTest(unittest.TestCase,
-                        RegisteredMessageTestMixin,
-                        SerializationMixin,):
+class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
+                        mixins.SerializationMixin,
+                        unittest.TestCase, ):
     FACTORY = factories.TaskToComputeFactory
     MSG_CLASS = message.tasks.TaskToCompute
+
+    def setUp(self):
+        self.msg = self.FACTORY()
 
     def test_task_to_compute_basic(self):
         ttc = factories.TaskToComputeFactory()
@@ -110,3 +115,28 @@ class TaskToComputeTest(unittest.TestCase,
                 'provider_ethereum_address'):
             address = getattr(msg_l, addr_slot)
             self.assertEqual(len(address), 2 + (20*2))
+
+    def test_task_id(self):
+        self.assertEqual(self.msg.task_id,
+                         self.msg.compute_task_def['task_id'])
+
+    def test_subtask_id(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.compute_task_def['subtask_id'])
+
+
+class ReportComputedTaskTest(mixins.RegisteredMessageTestMixin,
+                             mixins.SerializationMixin,
+                             unittest.TestCase):
+    FACTORY = factories.ReportComputedTaskFactory
+    MSG_CLASS = message.tasks.ReportComputedTask
+
+    def setUp(self):
+        self.msg = self.FACTORY()
+
+    def test_task_id(self):
+        self.assertEqual(self.msg.task_id, self.msg.task_to_compute.task_id)
+
+    def test_factory_subtask_id(self):
+        self.assertEqual(self.msg.subtask_id,
+                         self.msg.task_to_compute.subtask_id)


### PR DESCRIPTION
in the messages themselves, so that the retrieval of them doesn't require
ugly hacks later on...