### PR TITLE
AckReportComputedTask with report_computed_task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cache
 .idea
 .eggs
+.pytest_cache
 *.egg-info
 __pycache__
 *.py[co]

--- a/golem_messages/message/concents.py
+++ b/golem_messages/message/concents.py
@@ -33,8 +33,6 @@ class ServiceRefused(tasks.TaskMessageMixin, base.AbstractReasonMessage):
         ConcentDisabled = 'CONCENT_SERVICE_IS_NOT_ENABLED_FOR_THIS_SUBTASK'
 
     __slots__ = [
-        # @todo `subtask_id` is superfluous here
-        'subtask_id',
         'task_to_compute',
     ] + base.AbstractReasonMessage.__slots__
 
@@ -76,15 +74,13 @@ class AckReportComputedTask(tasks.TaskMessageMixin, base.Message):
     """
 
     TYPE = CONCENT_MSG_BASE + 2
-    TASK_ID_PROVIDERS = ('task_to_compute', )
+    TASK_ID_PROVIDERS = ('report_computed_task', )
 
     __slots__ = [
-        # @todo `subtask_id` is superfluous here
-        'subtask_id',
-        'task_to_compute',
+        'report_computed_task',
     ] + base.Message.__slots__
 
-    @base.verify_slot('task_to_compute', tasks.TaskToCompute)
+    @base.verify_slot('report_computed_task', tasks.ReportComputedTask)
     def deserialize_slot(self, key, value):
         return super().deserialize_slot(key, value)
 
@@ -118,8 +114,6 @@ class RejectReportComputedTask(tasks.TaskMessageMixin,
         GotMessageTaskFailure = 'GOT_MESSAGE_TASK_FAILURE'
 
     __slots__ = [
-        # @todo `subtask_id` is superfluous here
-        'subtask_id',
         'task_to_compute',
         'task_failure',
         'cannot_compute_task',

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -46,6 +46,7 @@ class ComputeTaskDef(datastructures.FrozenDict):
         max_length=128,
     )
 
+
 class TaskMessageMixin():
     __slots__ = []
     TASK_ID_PROVIDERS = ()
@@ -165,9 +166,6 @@ class ReportComputedTask(TaskMessageMixin, base.Message):
     TASK_ID_PROVIDERS = ('task_to_compute', )
 
     __slots__ = [
-        # @todo I'd remove the `subtask_id` from here as it's
-        # present within `task_to_compute` anyway...
-        'subtask_id',
         # TODO why do we need the type here?
         'result_type',
         'computation_time',

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -75,11 +75,7 @@ class ReportComputedTaskFactory(factory.Factory):
     class Meta:
         model = tasks.ReportComputedTask
 
-    subtask_id = factory.Faker('uuid4')
-    task_to_compute = factory.SubFactory(
-        TaskToComputeFactory,
-        compute_task_def__subtask_id=factory.SelfAttribute('...subtask_id'),
-    )
+    task_to_compute = factory.SubFactory(TaskToComputeFactory)
 
 
 class ForceReportComputedTaskFactory(factory.Factory):
@@ -248,21 +244,15 @@ class AckReportComputedTaskFactory(factory.Factory):
     class Meta:
         model = concents.AckReportComputedTask
 
-    subtask_id = factory.Faker('uuid4')
-    task_to_compute = factory.SubFactory(
-        TaskToComputeFactory,
-        compute_task_def__subtask_id=factory.SelfAttribute('...subtask_id'),
-    )
+    report_computed_task = factory.SubFactory(ReportComputedTaskFactory)
 
 
 class RejectReportComputedTaskFactory(factory.Factory):
     class Meta:
         model = concents.RejectReportComputedTask
 
-    subtask_id = factory.Faker('uuid4')
     task_to_compute = factory.SubFactory(
         TaskToComputeFactory,
-        compute_task_def__subtask_id=factory.SelfAttribute('...subtask_id'),
     )
 
 
@@ -362,10 +352,8 @@ class ForceReportComputedTaskResponseFactory(factory.Factory):
     ack_report_computed_task = factory.SubFactory(AckReportComputedTaskFactory)
     reject_report_computed_task = factory.SubFactory(
         RejectReportComputedTaskFactory,
-        subtask_id=factory.SelfAttribute(
-            '..ack_report_computed_task.task_to_compute.subtask_id'),
-        task_to_compute__compute_task_def__task_id=factory.SelfAttribute(
-            '....ack_report_computed_task.task_to_compute.task_id'),
+        task_to_compute__compute_task_def__subtask_id=factory.SelfAttribute('....ack_report_computed_task.report_computed_task.task_to_compute.subtask_id'),  # noqa pylint:disable=line-too-long
+        task_to_compute__compute_task_def__task_id=factory.SelfAttribute('....ack_report_computed_task.report_computed_task.task_to_compute.task_id'),  # noqa pylint:disable=line-too-long
     )
 
 
@@ -377,11 +365,10 @@ class VerdictReportComputedTaskFactory(factory.Factory):
         ForceReportComputedTaskFactory)
     ack_report_computed_task = factory.SubFactory(
         AckReportComputedTaskFactory,
-        subtask_id=factory.SelfAttribute(
-            '..force_report_computed_task.subtask_id'),
-        task_to_compute__compute_task_def__task_id=factory.SelfAttribute(
-            # noqa pylint:disable=line-too-long
-            '....force_report_computed_task.task_id'),
+        report_computed_task__task_to_compute__compute_task_def__subtask_id=factory.SelfAttribute(  # noqa pylint:disable=line-too-long
+            '.....force_report_computed_task.subtask_id'),
+        report_computed_task__task_to_compute__compute_task_def__task_id=factory.SelfAttribute(  # noqa pylint:disable=line-too-long
+            '.....force_report_computed_task.task_id'),
     )
 
 
@@ -396,8 +383,4 @@ class ServiceRefusedFactory(factory.Factory):
     class Meta:
         model = concents.ServiceRefused
 
-    subtask_id = factory.Faker('uuid4')
-    task_to_compute = factory.SubFactory(
-        TaskToComputeFactory,
-        compute_task_def__subtask_id=factory.SelfAttribute('...subtask_id'),
-    )
+    task_to_compute = factory.SubFactory(TaskToComputeFactory)

--- a/tests/message/mixins.py
+++ b/tests/message/mixins.py
@@ -25,6 +25,7 @@ class SerializationMixin():
         msg2 = golem_messages.load(s_msg, None, None)
         self.assertEqual(msg, msg2)
 
+
 class TaskIdMixinBase():
     TASK_ID_PROVIDER = None
 

--- a/tests/message/test_concents.py
+++ b/tests/message/test_concents.py
@@ -8,6 +8,7 @@ from golem_messages.message import concents
 from tests import factories
 from tests.message import mixins
 
+
 class ServiceRefusedTest(mixins.RegisteredMessageTestMixin,
                          mixins.SerializationMixin,
                          mixins.TaskIdTaskToComputeTestMixin,
@@ -548,7 +549,7 @@ class ForceReportComputedTaskResponseTestCase(
 
 class AckReportComputedTaskTestCase(
         mixins.RegisteredMessageTestMixin,
-        mixins.TaskIdTaskToComputeTestMixin,
+        mixins.TaskIdReportComputedTaskTestMixin,
         mixins.SerializationMixin,
         unittest.TestCase):
     MSG_CLASS = concents.AckReportComputedTask


### PR DESCRIPTION
fixes: #172 

Additionally removes redundant `subtask_id` provided by `tasks.TaskMessageMixin`