### PR TITLE
189 rm rct computation time 191 ttc and node id accessors

### DIFF
--- a/golem_messages/factories/concents.py
+++ b/golem_messages/factories/concents.py
@@ -321,7 +321,8 @@ class ForceReportComputedTaskResponseFactory(helpers.MessageFactory):
         return cls(
             *args, **kwargs,
             reject_report_computed_task___generate=True,
-            reject_report_computed_task__task_to_compute___generate=True,
+            reject_report_computed_task__attached_task_to_compute___generate=\
+                True,
         )
 
 

--- a/golem_messages/factories/helpers.py
+++ b/golem_messages/factories/helpers.py
@@ -31,6 +31,35 @@ def clone_message(
     )
 
 
+def call_subfactory(object_factory: factory.Factory,
+                    create, extracted, **kwargs):
+    if not (create or extracted or kwargs):
+        return None
+
+    generate = kwargs.pop('_generate', None)
+    if kwargs or generate:
+        extracted = object_factory(**kwargs)
+
+    return extracted
+
+
+def optional_subfactory(field: str, object_factory: factory.Factory):
+    """
+    Defines an optionally-called sub-factory triggered using a `___generate`
+    suffix on the parent factory's appropriate keyword argument
+
+    :param field: the name of the field the subfactory assigns to
+    :param object_factory: the factory to be called
+    :return: the sub-factory
+    """
+    def _subfactory(obj, create, extracted, **kwargs):
+        setattr(
+            obj, field,
+            call_subfactory(object_factory, create, extracted, **kwargs)
+        )
+    return factory.post_generation(_subfactory)
+
+
 class MessageFactory(factory.Factory):
 
     # pylint: disable=no-self-argument

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -65,7 +65,6 @@ class CannotComputeTaskFactory(helpers.MessageFactory):
     class Meta:
         model = tasks.CannotComputeTask
 
-    subtask_id = factory.Faker('uuid4')
     task_to_compute = factory.SubFactory(TaskToComputeFactory)
 
 
@@ -73,9 +72,8 @@ class TaskFailureFactory(helpers.MessageFactory):
     class Meta:
         model = tasks.TaskFailure
 
-    subtask_id = factory.Faker('uuid4')
-    err = factory.Faker('sentence')
     task_to_compute = factory.SubFactory(TaskToComputeFactory)
+    err = factory.Faker('sentence')
 
 
 class ReportComputedTaskFactory(helpers.MessageFactory):
@@ -83,7 +81,6 @@ class ReportComputedTaskFactory(helpers.MessageFactory):
         model = tasks.ReportComputedTask
 
     result_type = 0
-    computation_time = factory.Faker('pyfloat')
     node_name = factory.Faker('name')
     address = factory.Faker('ipv4')
     port = factory.Faker('pyint')

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -104,8 +104,8 @@ class RejectReportComputedTaskFactory(helpers.MessageFactory):
         model = tasks.RejectReportComputedTask
 
     reason = factory.fuzzy.FuzzyChoice(tasks.RejectReportComputedTask.REASON)
-    task_to_compute = helpers.optional_subfactory(
-        'task_to_compute', TaskToComputeFactory)
+    attached_task_to_compute = helpers.optional_subfactory(
+        'attached_task_to_compute', TaskToComputeFactory)
     task_failure = helpers.optional_subfactory(
         'task_failure', TaskFailureFactory)
     cannot_compute_task = helpers.optional_subfactory(
@@ -118,7 +118,7 @@ class RejectReportComputedTaskFactory(helpers.MessageFactory):
             kwargs.update({
                 'reason': cls._meta.model.REASON.SubtaskTimeLimitExceeded
             })
-        return cls(*args, **kwargs, task_to_compute___generate=True)
+        return cls(*args, **kwargs, attached_task_to_compute___generate=True)
 
     @classmethod
     def with_task_failure(cls, *args, **kwargs):

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -104,19 +104,37 @@ class RejectReportComputedTaskFactory(helpers.MessageFactory):
         model = tasks.RejectReportComputedTask
 
     reason = factory.fuzzy.FuzzyChoice(tasks.RejectReportComputedTask.REASON)
-    task_to_compute = factory.SubFactory(TaskToComputeFactory)
-    task_failure = factory.SubFactory(
-        TaskFailureFactory,
-        task_to_compute=factory.SelfAttribute(
-            '..task_to_compute',
-        )
+    task_to_compute = helpers.optional_subfactory(
+        'task_to_compute', TaskToComputeFactory)
+    task_failure = helpers.optional_subfactory(
+        'task_failure', TaskFailureFactory)
+    cannot_compute_task = helpers.optional_subfactory(
+        'cannot_compute_task', CannotComputeTaskFactory
     )
-    cannot_compute_task = factory.SubFactory(
-        CannotComputeTaskFactory,
-        task_to_compute=factory.SelfAttribute(
-            '..task_to_compute',
-        )
-    )
+
+    @classmethod
+    def with_task_to_compute(cls, *args, **kwargs):
+        if 'reason' not in kwargs:
+            kwargs.update({
+                'reason': cls._meta.model.REASON.SubtaskTimeLimitExceeded
+            })
+        return cls(*args, **kwargs, task_to_compute___generate=True)
+
+    @classmethod
+    def with_task_failure(cls, *args, **kwargs):
+        if 'reason' not in kwargs:
+            kwargs.update({
+                'reason': cls._meta.model.REASON.GotMessageTaskFailure
+            })
+        return cls(*args, **kwargs, task_failure___generate=True)
+
+    @classmethod
+    def with_cannot_compute_task(cls, *args, **kwargs):
+        if 'reason' not in kwargs:
+            kwargs.update({
+                'reason': cls._meta.model.REASON.GotMessageCannotComputeTask
+            })
+        return cls(*args, **kwargs, cannot_compute_task___generate=True)
 
 
 class SubtaskResultsAcceptedFactory(helpers.MessageFactory):

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -77,11 +77,11 @@ class TaskMessageMixin:
         return self._get_task_value('subtask_id')
 
     @property
-    def ttc(self):
+    def task_to_compute(self):
         """
         :return: the `TaskToCompute` related to this message chain
         """
-        return self._get_task_value('ttc')
+        return self._get_task_value('task_to_compute')
 
     @property
     def provider_id(self):
@@ -173,7 +173,7 @@ class TaskToCompute(TaskMessageMixin, base.Message):
         return None
 
     @property
-    def ttc(self):
+    def task_to_compute(self):
         return self
 
 
@@ -408,7 +408,7 @@ class AckReportComputedTask(TaskMessageMixin, base.Message):
 
 class RejectReportComputedTask(TaskMessageMixin, base.AbstractReasonMessage):
     TYPE = TASK_MSG_BASE + 30
-    TASK_ID_PROVIDERS = ('task_to_compute',
+    TASK_ID_PROVIDERS = ('attached_task_to_compute',
                          'task_failure',
                          'cannot_compute_task', )
 
@@ -434,12 +434,12 @@ class RejectReportComputedTask(TaskMessageMixin, base.AbstractReasonMessage):
         GotMessageTaskFailure = 'GOT_MESSAGE_TASK_FAILURE'
 
     __slots__ = [
-        'task_to_compute',
+        'attached_task_to_compute',
         'task_failure',
         'cannot_compute_task',
     ] + base.AbstractReasonMessage.__slots__
 
-    @base.verify_slot('task_to_compute', TaskToCompute)
+    @base.verify_slot('attached_task_to_compute_', TaskToCompute)
     @base.verify_slot('task_failure', TaskFailure)
     @base.verify_slot('cannot_compute_task', CannotComputeTask)
     def deserialize_slot(self, key, value):

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -67,7 +67,7 @@ class TaskMessageMixin:
         """
         :return: the `task_id` related to this message chain
         """
-        return self._get_task_value('task_id', )
+        return self._get_task_value('task_id')
 
     @property
     def subtask_id(self):

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -408,6 +408,13 @@ class AckReportComputedTask(TaskMessageMixin, base.Message):
 
 class RejectReportComputedTask(TaskMessageMixin, base.AbstractReasonMessage):
     TYPE = TASK_MSG_BASE + 30
+
+    #
+    # because other inner messages can also include `TaskToCompute`
+    # we need to differentiate between the universal `task_to_compute` accessor
+    # and the `TaskToCompute` attached directly into `RejectReportComputedTask`
+    # hence `attached_task_to_compute` which includes the directly attached TTC
+    #
     TASK_ID_PROVIDERS = ('attached_task_to_compute',
                          'task_failure',
                          'cannot_compute_task', )

--- a/tests/message/mixins.py
+++ b/tests/message/mixins.py
@@ -43,6 +43,22 @@ class TaskIdMixinBase():
         self.assertEqual(self.msg.subtask_id,
                          self.task_id_provider.subtask_id)
 
+    def test_ttc(self):
+        self.assertEqual(self.msg.ttc, self.task_id_provider.ttc)
+        self.assertIsInstance(self.msg.ttc, message.tasks.TaskToCompute)
+
+    def test_provider_id(self):
+        self.assertEqual(self.msg.provider_id,
+                         self.task_id_provider.provider_id)
+        self.assertEqual(self.msg.provider_id,
+                         self.msg.ttc.provider_id)
+
+    def test_requestor_id(self):
+        self.assertEqual(self.msg.requestor_id,
+                         self.task_id_provider.requestor_id)
+        self.assertEqual(self.msg.requestor_id,
+                         self.msg.ttc.requestor_id)
+
 
 class TaskIdTaskToComputeTestMixin(TaskIdMixinBase):
     TASK_ID_PROVIDER = 'task_to_compute'
@@ -58,3 +74,15 @@ class TaskIdForceGetTaskResultTestMixin(TaskIdMixinBase):
 
 class TaskIdAckReportComputedTaskTestMixin(TaskIdMixinBase):
     TASK_ID_PROVIDER = 'ack_report_computed_task'
+
+
+class TaskIdRejectReportComputedTaskTestMixin(TaskIdMixinBase):
+    TASK_ID_PROVIDER = 'reject_report_computed_task'
+
+
+class TaskIdCannotComputeTaskTestMixin(TaskIdMixinBase):
+    TASK_ID_PROVIDER = 'cannot_compute_task'
+
+
+class TaskIdTaskFailureTestMixin(TaskIdMixinBase):
+    TASK_ID_PROVIDER = 'task_failure'

--- a/tests/message/mixins.py
+++ b/tests/message/mixins.py
@@ -26,7 +26,7 @@ class SerializationMixin():
         self.assertEqual(msg, msg2)
 
 
-class TaskIdMixinBase():
+class TaskIdMixin:
     TASK_ID_PROVIDER = None
 
     @property
@@ -44,45 +44,19 @@ class TaskIdMixinBase():
                          self.task_id_provider.subtask_id)
 
     def test_ttc(self):
-        self.assertEqual(self.msg.ttc, self.task_id_provider.ttc)
-        self.assertIsInstance(self.msg.ttc, message.tasks.TaskToCompute)
+        self.assertEqual(
+            self.msg.task_to_compute, self.task_id_provider.task_to_compute)
+        self.assertIsInstance(
+            self.msg.task_to_compute, message.tasks.TaskToCompute)
 
     def test_provider_id(self):
         self.assertEqual(self.msg.provider_id,
                          self.task_id_provider.provider_id)
         self.assertEqual(self.msg.provider_id,
-                         self.msg.ttc.provider_id)
+                         self.msg.task_to_compute.provider_id)
 
     def test_requestor_id(self):
         self.assertEqual(self.msg.requestor_id,
                          self.task_id_provider.requestor_id)
         self.assertEqual(self.msg.requestor_id,
-                         self.msg.ttc.requestor_id)
-
-
-class TaskIdTaskToComputeTestMixin(TaskIdMixinBase):
-    TASK_ID_PROVIDER = 'task_to_compute'
-
-
-class TaskIdReportComputedTaskTestMixin(TaskIdMixinBase):
-    TASK_ID_PROVIDER = 'report_computed_task'
-
-
-class TaskIdForceGetTaskResultTestMixin(TaskIdMixinBase):
-    TASK_ID_PROVIDER = 'force_get_task_result'
-
-
-class TaskIdAckReportComputedTaskTestMixin(TaskIdMixinBase):
-    TASK_ID_PROVIDER = 'ack_report_computed_task'
-
-
-class TaskIdRejectReportComputedTaskTestMixin(TaskIdMixinBase):
-    TASK_ID_PROVIDER = 'reject_report_computed_task'
-
-
-class TaskIdCannotComputeTaskTestMixin(TaskIdMixinBase):
-    TASK_ID_PROVIDER = 'cannot_compute_task'
-
-
-class TaskIdTaskFailureTestMixin(TaskIdMixinBase):
-    TASK_ID_PROVIDER = 'task_failure'
+                         self.msg.task_to_compute.requestor_id)

--- a/tests/message/test_concents.py
+++ b/tests/message/test_concents.py
@@ -537,24 +537,17 @@ class ForceReportComputedTaskResponseTestCase(
     MSG_CLASS = concents.ForceReportComputedTaskResponse
     FACTORY = factories.concents.ForceReportComputedTaskResponseFactory
 
-    def setUp(self):
-        self.msg = self.FACTORY()
 
-    def test_task_id_ack(self):
-        self.assertEqual(self.msg.task_id,
-                         self.msg.ack_report_computed_task.task_id)
+class FrctAckTest(mixins.TaskIdAckReportComputedTaskTestMixin,
+                  unittest.TestCase):
+    FACTORY = factories.concents.ForceReportComputedTaskResponseFactory.\
+        with_ack_report_computed_task
 
-    def test_subtask_id_ack(self):
-        self.assertEqual(self.msg.subtask_id,
-                         self.msg.ack_report_computed_task.subtask_id)
 
-    def test_task_id_reject(self):
-        self.assertEqual(self.msg.task_id,
-                         self.msg.reject_report_computed_task.task_id)
-
-    def test_subtask_id_reject(self):
-        self.assertEqual(self.msg.subtask_id,
-                         self.msg.reject_report_computed_task.subtask_id)
+class FrctRejectTest(mixins.TaskIdRejectReportComputedTaskTestMixin,
+                     unittest.TestCase):
+    FACTORY = factories.concents.ForceReportComputedTaskResponseFactory.\
+        with_reject_report_computed_task
 
 
 class VerdictReportComputeTaskTestCase(

--- a/tests/message/test_concents.py
+++ b/tests/message/test_concents.py
@@ -11,10 +11,11 @@ from tests.message import mixins
 
 class ServiceRefusedTest(mixins.RegisteredMessageTestMixin,
                          mixins.SerializationMixin,
-                         mixins.TaskIdTaskToComputeTestMixin,
+                         mixins.TaskIdMixin,
                          unittest.TestCase):
     FACTORY = factories.concents.ServiceRefusedFactory
     MSG_CLASS = concents.ServiceRefused
+    TASK_ID_PROVIDER = 'task_to_compute'
 
 
 class FileTransferTokenTest(mixins.RegisteredMessageTestMixin,
@@ -121,10 +122,11 @@ class AckSubtaskResultsVerifyTest(mixins.RegisteredMessageTestMixin,
 
 class SubtaskResultsSettledTest(mixins.RegisteredMessageTestMixin,
                                 mixins.SerializationMixin,
-                                mixins.TaskIdTaskToComputeTestMixin,
+                                mixins.TaskIdMixin,
                                 unittest.TestCase):
     FACTORY = factories.concents.SubtaskResultsSettledFactory
     MSG_CLASS = concents.SubtaskResultsSettled
+    TASK_ID_PROVIDER = 'task_to_compute'
 
     def test_subtask_result_settled_no_acceptance(self):
         ttc = factories.tasks.TaskToComputeFactory()
@@ -156,10 +158,11 @@ class SubtaskResultsSettledTest(mixins.RegisteredMessageTestMixin,
 
 class ForceGetTaskResultTest(mixins.RegisteredMessageTestMixin,
                              mixins.SerializationMixin,
-                             mixins.TaskIdReportComputedTaskTestMixin,
+                             mixins.TaskIdMixin,
                              unittest.TestCase):
     FACTORY = factories.concents.ForceGetTaskResultFactory
     MSG_CLASS = message.concents.ForceGetTaskResult
+    TASK_ID_PROVIDER = 'report_computed_task'
 
     def test_force_get_task_result(self):
         rct = factories.tasks.ReportComputedTaskFactory()
@@ -177,10 +180,11 @@ class ForceGetTaskResultTest(mixins.RegisteredMessageTestMixin,
 
 class AckForceGetTaskResultTest(mixins.RegisteredMessageTestMixin,
                                 mixins.SerializationMixin,
-                                mixins.TaskIdForceGetTaskResultTestMixin,
+                                mixins.TaskIdMixin,
                                 unittest.TestCase):
     FACTORY = factories.concents.AckForceGetTaskResultFactory
     MSG_CLASS = message.concents.AckForceGetTaskResult
+    TASK_ID_PROVIDER = 'force_get_task_result'
 
     def test_ack_force_get_task_result(self):
         fgtr = factories.concents.ForceGetTaskResultFactory()
@@ -198,10 +202,11 @@ class AckForceGetTaskResultTest(mixins.RegisteredMessageTestMixin,
 
 class ForceGetTaskResultFailedTest(mixins.RegisteredMessageTestMixin,
                                    mixins.SerializationMixin,
-                                   mixins.TaskIdTaskToComputeTestMixin,
+                                   mixins.TaskIdMixin,
                                    unittest.TestCase):
     FACTORY = factories.concents.ForceGetTaskResultFailedFactory
     MSG_CLASS = message.concents.ForceGetTaskResultFailed
+    TASK_ID_PROVIDER = 'task_to_compute'
 
     def test_force_get_task_result_failed(self):
         ttc = factories.tasks.TaskToComputeFactory()
@@ -218,10 +223,11 @@ class ForceGetTaskResultFailedTest(mixins.RegisteredMessageTestMixin,
 
 class ForceGetTaskResultRejectedTest(mixins.RegisteredMessageTestMixin,
                                      mixins.SerializationMixin,
-                                     mixins.TaskIdForceGetTaskResultTestMixin,
+                                     mixins.TaskIdMixin,
                                      unittest.TestCase):
     FACTORY = factories.concents.ForceGetTaskResultRejectedFactory
     MSG_CLASS = message.concents.ForceGetTaskResultRejected
+    TASK_ID_PROVIDER = 'force_get_task_result'
 
     def test_force_get_task_result_rejected(self):
         fgtr = factories.concents.ForceGetTaskResultFactory()
@@ -240,10 +246,11 @@ class ForceGetTaskResultRejectedTest(mixins.RegisteredMessageTestMixin,
 
 class ForceGetTaskResultUploadTest(mixins.RegisteredMessageTestMixin,
                                    mixins.SerializationMixin,
-                                   mixins.TaskIdForceGetTaskResultTestMixin,
+                                   mixins.TaskIdMixin,
                                    unittest.TestCase):
     FACTORY = factories.concents.ForceGetTaskResultUploadFactory
     MSG_CLASS = message.concents.ForceGetTaskResultUpload
+    TASK_ID_PROVIDER = 'force_get_task_result'
 
     def test_force_get_task_result_upload(self):
         fgtr = factories.concents.ForceGetTaskResultFactory()
@@ -266,10 +273,11 @@ class ForceGetTaskResultUploadTest(mixins.RegisteredMessageTestMixin,
 
 class ForceGetTaskResultDownloadTest(mixins.RegisteredMessageTestMixin,
                                      mixins.SerializationMixin,
-                                     mixins.TaskIdForceGetTaskResultTestMixin,
+                                     mixins.TaskIdMixin,
                                      unittest.TestCase):
     FACTORY = factories.concents.ForceGetTaskResultDownloadFactory
     MSG_CLASS = message.concents.ForceGetTaskResultDownload
+    TASK_ID_PROVIDER = 'force_get_task_result'
 
     def test_force_get_task_result_download(self):
         fgtr = factories.concents.ForceGetTaskResultFactory()
@@ -292,10 +300,11 @@ class ForceGetTaskResultDownloadTest(mixins.RegisteredMessageTestMixin,
 
 class ForceSubtaskResultsTest(mixins.RegisteredMessageTestMixin,
                               mixins.SerializationMixin,
-                              mixins.TaskIdAckReportComputedTaskTestMixin,
+                              mixins.TaskIdMixin,
                               unittest.TestCase):
     FACTORY = factories.concents.ForceSubtaskResultsFactory
     MSG_CLASS = concents.ForceSubtaskResults
+    TASK_ID_PROVIDER = 'ack_report_computed_task'
 
     def test_force_subtask_results(self):
         ack_rct = factories.tasks.AckReportComputedTaskFactory()
@@ -523,11 +532,12 @@ class ForcePaymentRejectedTest(mixins.RegisteredMessageTestMixin,
 
 class ForceReportComputedTaskTestCase(
         mixins.RegisteredMessageTestMixin,
-        mixins.TaskIdReportComputedTaskTestMixin,
+        mixins.TaskIdMixin,
         mixins.SerializationMixin,
         unittest.TestCase):
     MSG_CLASS = concents.ForceReportComputedTask
     FACTORY = factories.concents.ForceReportComputedTaskFactory
+    TASK_ID_PROVIDER = 'report_computed_task'
 
 
 class ForceReportComputedTaskResponseTestCase(
@@ -538,16 +548,17 @@ class ForceReportComputedTaskResponseTestCase(
     FACTORY = factories.concents.ForceReportComputedTaskResponseFactory
 
 
-class FrctAckTest(mixins.TaskIdAckReportComputedTaskTestMixin,
+class FrctAckTest(mixins.TaskIdMixin,
                   unittest.TestCase):
     FACTORY = factories.concents.ForceReportComputedTaskResponseFactory.\
         with_ack_report_computed_task
+    TASK_ID_PROVIDER = 'ack_report_computed_task'
 
 
-class FrctRejectTest(mixins.TaskIdRejectReportComputedTaskTestMixin,
-                     unittest.TestCase):
+class FrctRejectTest(mixins.TaskIdMixin, unittest.TestCase):
     FACTORY = factories.concents.ForceReportComputedTaskResponseFactory.\
         with_reject_report_computed_task
+    TASK_ID_PROVIDER = 'reject_report_computed_task'
 
 
 class VerdictReportComputeTaskTestCase(

--- a/tests/message/test_messages.py
+++ b/tests/message/test_messages.py
@@ -6,9 +6,9 @@ import unittest.mock as mock
 import uuid
 
 from golem_messages import datastructures
+from golem_messages import factories
 from golem_messages import message
 from golem_messages import shortcuts
-
 
 class InitializationTestCase(unittest.TestCase):
     def test_default_slots(self):
@@ -253,22 +253,21 @@ class MessagesTestCase(unittest.TestCase):
         self.assertEqual(expected, msg.slots())
 
     def test_message_task_failure(self):
-        subtask_id = 'test-si-{}'.format(uuid.uuid4())
+        ttc = factories.tasks.TaskToComputeFactory()
         err = (
             'Przesąd ten istnieje po dziś dzień u Mordwy, lecz już tylko '
             'symbol tego pozostał, co niegdyś dziki Fin w istocie tworzył.'
         )
 
-        msg = message.TaskFailure(subtask_id=subtask_id, err=err)
+        msg = message.TaskFailure(task_to_compute=ttc, err=err)
         expected = sorted([
-            ['subtask_id', subtask_id],
+            ['task_to_compute', ttc],
             ['err', err],
-            ['task_to_compute', None],
         ])
         self.assertEqual(expected, sorted(msg.slots()))
 
     def test_message_cannot_compute_task(self):
-        subtask_id = 'test-si-{}'.format(uuid.uuid4())
+        ttc = factories.tasks.TaskToComputeFactory()
         reason = (
             "Opowiada Hieronim praski o osobliwszej czci, jaką w głębi Litwy"
             " cieszył się żelazny młot niezwykłej wielkości; „znaki zodiaka”"
@@ -281,11 +280,10 @@ class MessagesTestCase(unittest.TestCase):
             " jak wysoko chłop litewski cenił własności „kopalnego” młota"
             " (zeskrobany proszek z wodą przeciw chorobom służył itd.)."
         )
-        msg = message.CannotComputeTask(subtask_id=subtask_id, reason=reason)
+        msg = message.CannotComputeTask(task_to_compute=ttc, reason=reason)
         expected = sorted([
+            ['task_to_compute', ttc],
             ['reason', reason],
-            ['subtask_id', subtask_id],
-            ['task_to_compute', None],
         ])
         self.assertEqual(expected, sorted(msg.slots()))
 

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -165,4 +165,19 @@ class RejectReportComputedTaskTestCase(
         mixins.SerializationMixin,
         unittest.TestCase):
     MSG_CLASS = message.tasks.RejectReportComputedTask
-    FACTORY = factories.tasks.RejectReportComputedTaskFactory
+    FACTORY = factories.tasks.RejectReportComputedTaskFactory.\
+        with_task_to_compute
+
+
+class RejectRctCctTestCase(mixins.TaskIdCannotComputeTaskTestMixin,
+                           unittest.TestCase):
+    MSG_CLASS = message.tasks.RejectReportComputedTask
+    FACTORY = factories.tasks.RejectReportComputedTaskFactory.\
+        with_cannot_compute_task
+
+
+class RejectRctTfTestCase(mixins.TaskIdTaskFailureTestMixin,
+                          unittest.TestCase):
+    MSG_CLASS = message.tasks.RejectReportComputedTask
+    FACTORY = factories.tasks.RejectReportComputedTaskFactory.\
+        with_task_failure

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -32,10 +32,11 @@ class ComputeTaskDefTestCase(unittest.TestCase):
 
 class SubtaskResultsAcceptedTest(mixins.RegisteredMessageTestMixin,
                                  mixins.SerializationMixin,
-                                 mixins.TaskIdTaskToComputeTestMixin,
+                                 mixins.TaskIdMixin,
                                  unittest.TestCase):
     FACTORY = factories.tasks.SubtaskResultsAcceptedFactory
     MSG_CLASS = message.tasks.SubtaskResultsAccepted
+    TASK_ID_PROVIDER = 'task_to_compute'
 
     def test_factory(self):
         self.assertIsInstance(self.msg, message.tasks.SubtaskResultsAccepted)
@@ -55,10 +56,11 @@ class SubtaskResultsAcceptedTest(mixins.RegisteredMessageTestMixin,
 
 class SubtaskResultsRejectedTest(mixins.RegisteredMessageTestMixin,
                                  mixins.SerializationMixin,
-                                 mixins.TaskIdReportComputedTaskTestMixin,
+                                 mixins.TaskIdMixin,
                                  unittest.TestCase):
     FACTORY = factories.tasks.SubtaskResultsRejectedFactory
     MSG_CLASS = message.tasks.SubtaskResultsRejected
+    TASK_ID_PROVIDER = 'report_computed_task'
 
     def test_subtask_results_rejected_factory(self):
         msg = factories.tasks.SubtaskResultsRejectedFactory()
@@ -152,32 +154,34 @@ class ReportComputedTaskTest(mixins.RegisteredMessageTestMixin,
 
 class AckReportComputedTaskTestCase(
         mixins.RegisteredMessageTestMixin,
-        mixins.TaskIdReportComputedTaskTestMixin,
+        mixins.TaskIdMixin,
         mixins.SerializationMixin,
         unittest.TestCase):
     MSG_CLASS = message.tasks.AckReportComputedTask
     FACTORY = factories.tasks.AckReportComputedTaskFactory
+    TASK_ID_PROVIDER = 'report_computed_task'
 
 
 class RejectReportComputedTaskTestCase(
         mixins.RegisteredMessageTestMixin,
-        mixins.TaskIdTaskToComputeTestMixin,
+        mixins.TaskIdMixin,
         mixins.SerializationMixin,
         unittest.TestCase):
     MSG_CLASS = message.tasks.RejectReportComputedTask
     FACTORY = factories.tasks.RejectReportComputedTaskFactory.\
         with_task_to_compute
+    TASK_ID_PROVIDER = 'attached_task_to_compute'
 
 
-class RejectRctCctTestCase(mixins.TaskIdCannotComputeTaskTestMixin,
-                           unittest.TestCase):
+class RejectRctCctTestCase(mixins.TaskIdMixin, unittest.TestCase):
     MSG_CLASS = message.tasks.RejectReportComputedTask
     FACTORY = factories.tasks.RejectReportComputedTaskFactory.\
         with_cannot_compute_task
+    TASK_ID_PROVIDER = 'cannot_compute_task'
 
 
-class RejectRctTfTestCase(mixins.TaskIdTaskFailureTestMixin,
-                          unittest.TestCase):
+class RejectRctTfTestCase(mixins.TaskIdMixin, unittest.TestCase):
     MSG_CLASS = message.tasks.RejectReportComputedTask
     FACTORY = factories.tasks.RejectReportComputedTaskFactory.\
         with_task_failure
+    TASK_ID_PROVIDER = 'task_failure'


### PR DESCRIPTION
closes #189
closes #191

+ `TaskMessageMixin.ttc`
+ `TaskMessageMixin.provider_id`
+ `TaskMessageMixin.requestor_id`

- redundant `CannotComputeTask.subtask_id`
- redundant `TaskFailure.subtask_id`
- unused `ReportComputedTask.computation_time`

`RejectReportComputedTask.task_to_compute` is getting replaced with `RejectReportComputedTask.attached_task_to_compute`

+ message factory fixes