### PR TITLE
192a ownership checks

### DIFF
--- a/golem_messages/exceptions.py
+++ b/golem_messages/exceptions.py
@@ -60,3 +60,11 @@ class SignatureAlreadyExists(SerializationError):
 
 class VersionMismatchError(MessageError):
     pass
+
+
+class OwnershipMismatch(MessageError):
+    pass
+
+
+class ValidationError(MessageError):
+    pass

--- a/golem_messages/message/base.py
+++ b/golem_messages/message/base.py
@@ -515,7 +515,6 @@ class Message():
         :param msg_hash: if provided, a call to `get_short_hash()`
                          will be skipped and the provided hash used instead
         :return: `True` if the signature is correct.
-        :raises: `exceptions.CoincurveError` if the signature is missing
         :raises: `exceptions.InvalidSignature` if the signature is corrupted
         """
         return cryptography.ecdsa_verify(

--- a/golem_messages/message/concents.py
+++ b/golem_messages/message/concents.py
@@ -9,7 +9,7 @@ from . import tasks
 CONCENT_MSG_BASE = 4000
 
 
-class ServiceRefused(tasks.TaskMessageMixin, base.AbstractReasonMessage):
+class ServiceRefused(tasks.TaskMessage, base.AbstractReasonMessage):
     """
     Sent (synchronously) as a response from the Concent to the calling party
     (either a Provider or a Requestor), informing them that the Concent refuses
@@ -41,7 +41,7 @@ class ServiceRefused(tasks.TaskMessageMixin, base.AbstractReasonMessage):
         return super().deserialize_slot(key, value)
 
 
-class ForceReportComputedTask(tasks.TaskMessageMixin, base.Message):
+class ForceReportComputedTask(tasks.TaskMessage):
     """
     Message sent from a Provider to the Concent, requesting an forced
     acknowledgment of the reception of the `ReportComputedTask` message
@@ -62,7 +62,7 @@ class ForceReportComputedTask(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class VerdictReportComputedTask(tasks.TaskMessageMixin, base.Message):
+class VerdictReportComputedTask(tasks.TaskMessage):
     """
     Informational message sent from from the Concent to the affected
     Requestor, informing them that the `ReportComputedTask` has been implicitly
@@ -135,7 +135,7 @@ class FileTransferToken(base.Message):
         return self.operation == self.Operation.download
 
 
-class SubtaskResultsVerify(tasks.TaskMessageMixin, base.Message):
+class SubtaskResultsVerify(tasks.TaskMessage):
     """
     Message sent from a Provider to the Concent, requesting additional
     verification in case the result had been rejected by the Requestor
@@ -156,7 +156,7 @@ class SubtaskResultsVerify(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class AckSubtaskResultsVerify(tasks.TaskMessageMixin, base.Message):
+class AckSubtaskResultsVerify(tasks.TaskMessage):
     """
     Message sent from the Concent to the Provider to acknowledge reception
     of the `SubtaskResultsVerify` message and more importantly, to pass the
@@ -177,7 +177,7 @@ class AckSubtaskResultsVerify(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class SubtaskResultsSettled(tasks.TaskMessageMixin, base.Message):
+class SubtaskResultsSettled(tasks.TaskMessage):
     """
     Message sent from the Concent to both the Provider and the Requestor
     informing of positive acceptance of the results by the Concent and the
@@ -214,7 +214,7 @@ class SubtaskResultsSettled(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResult(tasks.TaskMessageMixin, base.Message):
+class ForceGetTaskResult(tasks.TaskMessage):
     TYPE = CONCENT_MSG_BASE + 9
     TASK_ID_PROVIDERS = ('report_computed_task', )
 
@@ -227,7 +227,7 @@ class ForceGetTaskResult(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class AckForceGetTaskResult(tasks.TaskMessageMixin, base.Message):
+class AckForceGetTaskResult(tasks.TaskMessage):
     TYPE = CONCENT_MSG_BASE + 10
     TASK_ID_PROVIDERS = ('force_get_task_result', )
 
@@ -240,7 +240,7 @@ class AckForceGetTaskResult(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultFailed(tasks.TaskMessageMixin, base.Message):
+class ForceGetTaskResultFailed(tasks.TaskMessage):
     """
     Sent from the Concent to the Requestor to announce a failure to retrieve
     the results from the Provider.
@@ -261,7 +261,7 @@ class ForceGetTaskResultFailed(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultRejected(tasks.TaskMessageMixin,
+class ForceGetTaskResultRejected(tasks.TaskMessage,
                                  base.AbstractReasonMessage):
     TYPE = CONCENT_MSG_BASE + 12
     TASK_ID_PROVIDERS = ('force_get_task_result', )
@@ -278,7 +278,7 @@ class ForceGetTaskResultRejected(tasks.TaskMessageMixin,
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultUpload(tasks.TaskMessageMixin, base.Message):
+class ForceGetTaskResultUpload(tasks.TaskMessage):
     TYPE = CONCENT_MSG_BASE + 13
     TASK_ID_PROVIDERS = ('force_get_task_result', )
 
@@ -293,7 +293,7 @@ class ForceGetTaskResultUpload(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceGetTaskResultDownload(tasks.TaskMessageMixin, base.Message):
+class ForceGetTaskResultDownload(tasks.TaskMessage):
     TYPE = CONCENT_MSG_BASE + 14
     TASK_ID_PROVIDERS = ('force_get_task_result', )
 
@@ -308,7 +308,7 @@ class ForceGetTaskResultDownload(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceSubtaskResults(tasks.TaskMessageMixin, base.Message):
+class ForceSubtaskResults(tasks.TaskMessage):
     """
     Sent from the Provider to the Concent, in an effort to force the
     `SubtaskResultsAccepted/Rejected` message from the Requestor
@@ -331,7 +331,7 @@ class ForceSubtaskResults(tasks.TaskMessageMixin, base.Message):
         return super().deserialize_slot(key, value)
 
 
-class ForceSubtaskResultsResponse(tasks.TaskMessageMixin, base.Message):
+class ForceSubtaskResultsResponse(tasks.TaskMessage):
     """
     Sent from the Concent to the Provider to communicate the final resolution
     of the forced results verdict.
@@ -453,7 +453,7 @@ class ForcePaymentRejected(base.AbstractReasonMessage):
         return super().deserialize_slot(key, value)
 
 
-class ForceReportComputedTaskResponse(tasks.TaskMessageMixin,
+class ForceReportComputedTaskResponse(tasks.TaskMessage,
                                       base.AbstractReasonMessage):
     """Sent from Concent to Provider as a response to ForceReportComputedTask.
     """

--- a/golem_messages/message/concents.py
+++ b/golem_messages/message/concents.py
@@ -21,6 +21,7 @@ class ServiceRefused(tasks.TaskMessage, base.AbstractReasonMessage):
     """
     TYPE = CONCENT_MSG_BASE
     TASK_ID_PROVIDERS = ('task_to_compute', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     @enum.unique
     class REASON(enum.Enum):
@@ -51,6 +52,8 @@ class ForceReportComputedTask(tasks.TaskMessage):
     """
     TYPE = CONCENT_MSG_BASE + 1
     TASK_ID_PROVIDERS = ('report_computed_task', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.provider,
+                       tasks.TaskMessage.OWNER_CHOICES.concent)
 
     __slots__ = [
         'report_computed_task',
@@ -75,6 +78,7 @@ class VerdictReportComputedTask(tasks.TaskMessage):
     TYPE = CONCENT_MSG_BASE + 4
     TASK_ID_PROVIDERS = ('force_report_computed_task',
                          'ack_report_computed_task', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'force_report_computed_task',
@@ -146,6 +150,7 @@ class SubtaskResultsVerify(tasks.TaskMessage):
     """
     TYPE = CONCENT_MSG_BASE + 6
     TASK_ID_PROVIDERS = ('subtask_results_rejected', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.provider, )
 
     __slots__ = [
         'subtask_results_rejected',
@@ -165,6 +170,7 @@ class AckSubtaskResultsVerify(tasks.TaskMessage):
     """
     TYPE = CONCENT_MSG_BASE + 7
     TASK_ID_PROVIDERS = ('subtask_results_verify', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'subtask_results_verify',
@@ -194,6 +200,7 @@ class SubtaskResultsSettled(tasks.TaskMessage):
 
     TYPE = CONCENT_MSG_BASE + 8
     TASK_ID_PROVIDERS = ('task_to_compute', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     @enum.unique
     class Origin(enum.Enum):
@@ -215,8 +222,13 @@ class SubtaskResultsSettled(tasks.TaskMessage):
 
 
 class ForceGetTaskResult(tasks.TaskMessage):
+    """
+    Sent from the Requestor to the Concent, requesting assistance in
+    downloading the results from the Provider.
+    """
     TYPE = CONCENT_MSG_BASE + 9
     TASK_ID_PROVIDERS = ('report_computed_task', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.requestor, )
 
     __slots__ = [
         'report_computed_task',
@@ -228,8 +240,13 @@ class ForceGetTaskResult(tasks.TaskMessage):
 
 
 class AckForceGetTaskResult(tasks.TaskMessage):
+    """
+    Sent from the Concent to the Requestor to acknowledge reception of the
+    `ForceGetTaskResult` message
+    """
     TYPE = CONCENT_MSG_BASE + 10
     TASK_ID_PROVIDERS = ('force_get_task_result', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'force_get_task_result',
@@ -251,6 +268,7 @@ class ForceGetTaskResultFailed(tasks.TaskMessage):
     """
     TYPE = CONCENT_MSG_BASE + 11
     TASK_ID_PROVIDERS = ('task_to_compute', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'task_to_compute',
@@ -263,8 +281,13 @@ class ForceGetTaskResultFailed(tasks.TaskMessage):
 
 class ForceGetTaskResultRejected(tasks.TaskMessage,
                                  base.AbstractReasonMessage):
+    """
+    Sent from the Concent to the Requestor to notify them that the
+    `ForceGetTaskResult` message was not allowed at this time
+    """
     TYPE = CONCENT_MSG_BASE + 12
     TASK_ID_PROVIDERS = ('force_get_task_result', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'force_get_task_result',
@@ -279,8 +302,13 @@ class ForceGetTaskResultRejected(tasks.TaskMessage,
 
 
 class ForceGetTaskResultUpload(tasks.TaskMessage):
+    """
+    Sent from the Concent to the Provider to notify them they can (and need to)
+    upload the results to them
+    """
     TYPE = CONCENT_MSG_BASE + 13
     TASK_ID_PROVIDERS = ('force_get_task_result', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'force_get_task_result',
@@ -294,8 +322,13 @@ class ForceGetTaskResultUpload(tasks.TaskMessage):
 
 
 class ForceGetTaskResultDownload(tasks.TaskMessage):
+    """
+    Sent from the Concent to the Requestor to notify them that the results
+    are available for download.
+    """
     TYPE = CONCENT_MSG_BASE + 14
     TASK_ID_PROVIDERS = ('force_get_task_result', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'force_get_task_result',
@@ -321,6 +354,7 @@ class ForceSubtaskResults(tasks.TaskMessage):
     """
     TYPE = CONCENT_MSG_BASE + 15
     TASK_ID_PROVIDERS = ('ack_report_computed_task', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.provider, )
 
     __slots__ = [
         'ack_report_computed_task',
@@ -344,6 +378,7 @@ class ForceSubtaskResultsResponse(tasks.TaskMessage):
     TYPE = CONCENT_MSG_BASE + 16
     TASK_ID_PROVIDERS = ('subtask_results_accepted',
                          'subtask_results_rejected', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     __slots__ = [
         'subtask_results_accepted',
@@ -460,6 +495,7 @@ class ForceReportComputedTaskResponse(tasks.TaskMessage,
     TYPE = CONCENT_MSG_BASE + 21
     TASK_ID_PROVIDERS = ('ack_report_computed_task',
                          'reject_report_computed_task', )
+    EXPECTED_OWNERS = (tasks.TaskMessage.OWNER_CHOICES.concent, )
 
     @enum.unique
     class REASON(enum.Enum):

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -316,4 +316,3 @@ class TaskMessageVerificationTest(unittest.TestCase):
                 requestor_public_key=self.other_keys.raw_pubkey,
             )
         self.assertIn('requestor', str(e.exception))
-


### PR DESCRIPTION
`TaskMessage`

+ `validate_ownership()` - validates the message against the expected role
+ `validate_ownership_chain()` - validates the chain of messages against their respective roles
+ `verify_owners()` - validates + verifies the chain ownership against the specified keys
+ `is_valid()` - general additional validation hook