### PR TITLE
concent_enabled flag in WantToComputeTask

### DIFF
--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -226,7 +226,9 @@ class WantToComputeTask(base.Message):
         'max_resource_size',
         'max_memory_size',
         'num_cores',
-        'price'
+        'price',
+        'concent_enabled',  # Provider notifies requestor
+                            # about his concent status
     ] + base.Message.__slots__
 
 
@@ -244,7 +246,7 @@ class TaskToCompute(TaskMessage):
         'compute_task_def',
         'package_hash',
         'concent_enabled',
-        'price', # total subtask price computed as `price * subtask_timeout`
+        'price',  # total subtask price computed as `price * subtask_timeout`
     ] + base.Message.__slots__
 
     def __init__(self, header: datastructures.MessageHeader = None,

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -305,9 +305,10 @@ class CannotAssignTask(base.AbstractReasonMessage):
         'task_id'
     ] + base.AbstractReasonMessage.__slots__
 
-    class REASON(enum.Enum):
-        NotMyTask = 'not_my_task'
-        NoMoreSubtasks = 'no_more_subtasks'
+    class REASON(datastructures.StringEnum):
+        NotMyTask = enum.auto()
+        NoMoreSubtasks = enum.auto()
+        ConcentDisabled = enum.auto()
 
 
 class ReportComputedTask(TaskMessage):

--- a/tests/message/test_messages.py
+++ b/tests/message/test_messages.py
@@ -50,6 +50,7 @@ class MessagesTestCase(unittest.TestCase):
         max_resource_size = random.randint(1, 2**10)
         max_memory_size = random.randint(1, 2**10)
         num_cores = random.randint(1, 2**5)
+        concent_enabled = random.random() > 0.5
         msg = message.WantToComputeTask(
             node_name=node_id,
             task_id=task_id,
@@ -57,7 +58,8 @@ class MessagesTestCase(unittest.TestCase):
             price=price,
             max_resource_size=max_resource_size,
             max_memory_size=max_memory_size,
-            num_cores=num_cores)
+            num_cores=num_cores,
+            concent_enabled=concent_enabled)
         expected = [
             ['node_name', node_id],
             ['task_id', task_id],
@@ -66,6 +68,7 @@ class MessagesTestCase(unittest.TestCase):
             ['max_memory_size', max_memory_size],
             ['num_cores', num_cores],
             ['price', price],
+            ['concent_enabled', concent_enabled],
         ]
         self.assertEqual(expected, msg.slots())
 


### PR DESCRIPTION
This allows Requestor to avoid sending `TaskToCompute` if it cannot meet Providers` requirements.