### PR TITLE
Add `category` enum to `FileTransferToken.FileInfo`

### DIFF
--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -12,7 +12,7 @@ from . import base
 TASK_MSG_BASE = 2000
 
 
-class ComputeTaskDef(datastructures.FrozenDict):
+class ComputeTaskDef(datastructures.ValidatingDict, datastructures.FrozenDict):
     """Represents SUBTASK metadata."""
     ITEMS = {
         'task_id': '',
@@ -28,12 +28,6 @@ class ComputeTaskDef(datastructures.FrozenDict):
         'performance': 0,
         'docker_images': None,
     }
-
-    def __setitem__(self, key, value):
-        validator = getattr(self, 'validate_{}'.format(key), None)
-        if validator is not None:
-            validator(value=value)  # pylint: disable=not-callable
-        super().__setitem__(key, value)
 
     validate_task_id = functools.partial(
         validators.validate_varchar,

--- a/tests/message/test_concents.py
+++ b/tests/message/test_concents.py
@@ -18,9 +18,11 @@ class ServiceRefusedTest(mixins.RegisteredMessageTestMixin,
     TASK_ID_PROVIDER = 'task_to_compute'
 
 
-class FileTransferTokenTest(mixins.RegisteredMessageTestMixin,
+class FileTransferTokenTest(mixins.SerializationMixin,
+                            mixins.RegisteredMessageTestMixin,
                             unittest.TestCase):
     MSG_CLASS = concents.FileTransferToken
+    FACTORY = factories.concents.FileTransferTokenFactory
 
     def test_operation_upload(self):
         ftt = concents.FileTransferToken(slots=(
@@ -51,6 +53,20 @@ class FileTransferTokenTest(mixins.RegisteredMessageTestMixin,
         path = ftt.files[0].get('path')  # noqa pylint:disable=unsubscriptable-object
         self.assertGreater(len(path), 1)
         self.assertNotEqual('/', path[:1])
+
+    def test_file_info_category_default(self):
+        fi = concents.FileTransferToken.FileInfo()
+        self.assertIsNotNone(fi.get('category'))
+
+    def test_file_info_category_wrong(self):
+        with self.assertRaises(exceptions.FieldError):
+            concents.FileTransferToken.FileInfo({'category': 'other'})
+
+    def test_file_info_category_given(self):
+        cat = concents.FileTransferToken.FileInfo.Category.resources
+        fi = concents.FileTransferToken.FileInfo(
+            {'category': cat})
+        self.assertEqual(fi.get('category'), cat)
 
 
 class SubtaskResultsVerifyTest(mixins.RegisteredMessageTestMixin,


### PR DESCRIPTION
+ frozendict default values test
* pull `SetItemDict` out of `FrozenDict`
* ensure that `FrozenDict` defaults are really its defaults and not just `defaultdict`-like fallbacks
+ `ValidatingDict` class to abstract the validation interface from `ComputeTaskDef`
+ validation for `FileTransferToken.FileInfo`'s new `category` field
+ tests

closes #214