### PR TITLE
PoC Remove docker_images and env from ComputeTaskDef

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
        - checkout
        - restore_cache:
            key: deps1-{{ .Branch }}-{{ checksum "setup.py" }}
-       - run: sudo apt-get install -y libgmp3-dev
+       - run: sudo apt-get install -y libgmp3-dev libsecp256k1-0 libsecp256k1-dev
        - run: sudo pip install coverage codecov
        - run:
            command: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,6 +4,8 @@ disable=invalid-name,                   # Pylint is overzealous here
         access-member-before-definition,
         fixme,
         no-member,
+        useless-import-alias,           # 2018-05-21 Bug in pylint triggers this on lines with "import unittest.mock as mock"
+        try-except-raise,
 
 [TYPECHECK]
 

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -17,6 +17,7 @@ class ComputeTaskDef(datastructures.FrozenDict):
     ITEMS = {
         'task_id': '',
         'subtask_id': '',
+        'task_type': '',
         # deadline represents subtask timeout in UTC timestamp (float or int)
         # If you're looking for whole TASK deadline SEE: task_header.deadline
         # Task headers are received in MessageTasks.tasks.
@@ -26,7 +27,6 @@ class ComputeTaskDef(datastructures.FrozenDict):
         'short_description': '',
         'working_directory': '',
         'performance': 0,
-        'docker_images': None,
     }
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
Removed docker_images and enviromnent from ComputeTaskDef, replacing them with task_type.

The idea is that provider will select the best local environment based on
task_type. That way the way task is evaluated is dynamic and different
providers can implement different strategies for evaluating the same task_type.
