### PR TITLE
New task message: StateUpdate

### DIFF
--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -231,3 +231,8 @@ class SubtaskResultsRejectedFactory(helpers.MessageFactory):
         model = tasks.SubtaskResultsRejected
 
     report_computed_task = factory.SubFactory(ReportComputedTaskFactory)
+
+
+class StateUpdateFactory(helpers.MessageFactory):
+    class Meta:
+        model = tasks.StateUpdate

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -259,3 +259,8 @@ class SubtaskResultsRejectedFactory(helpers.MessageFactory):
 class StateUpdateFactory(helpers.MessageFactory):
     class Meta:
         model = tasks.StateUpdate
+    state_update_id = factory.Faker('text')
+    task_id = factory.Faker('uuid4')
+    subtask_id = factory.Faker('uuid4')
+    data = factory.Faker('binary')
+    direction = factory.fuzzy.FuzzyChoice(tasks.StateUpdate.DIRECTION)

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -634,3 +634,28 @@ class RejectReportComputedTask(TaskMessage, base.AbstractReasonMessage):
     @base.verify_slot('cannot_compute_task', CannotComputeTask)
     def deserialize_slot(self, key, value):
         return super().deserialize_slot(key, value)
+
+@library.register(TASK_MSG_BASE + 31)
+class StateUpdate(base.Message):
+
+    @enum.unique
+    class DIRECTION(datastructures.StringEnum):
+        Call = enum.auto()
+        Response = enum.auto()
+
+    __slots__ = [
+        'data',
+        'state_update_id',
+        'direction',
+        # task_id and subtask_id are added here manually to avoid inheriting
+        # from TaskMessage - since this message doesn't need any other fields
+        'task_id',
+        'subtask_id'
+    ] + base.Message.__slots__
+
+    @base.verify_slot('direction', DIRECTION)
+    @base.verify_slot('state_update_id', str)
+    @base.verify_slot('task_id', str)
+    @base.verify_slot('subtask_id', str)
+    def deserialize_slot(self, key, value):
+        return super().deserialize_slot(key, value)

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -3,6 +3,7 @@ import functools
 import struct
 import typing
 
+from eth_utils import to_checksum_address
 from ethereum.utils import sha3
 
 from golem_messages import datastructures
@@ -261,13 +262,13 @@ class TaskToCompute(ConcentEnabled, TaskMessage):
 
     @property
     def requestor_ethereum_address(self):
-        return '0x{}'.format(
-            sha3(decode_hex(self.requestor_ethereum_public_key))[12:].hex(),
+        return to_checksum_address(
+            sha3(decode_hex(self.requestor_ethereum_public_key))[12:].hex()
         )
 
     @property
     def provider_ethereum_address(self):
-        return '0x{}'.format(
+        return to_checksum_address(
             sha3(decode_hex(self.provider_ethereum_public_key))[12:].hex(),
         )
 

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -712,7 +712,6 @@ class StateUpdate(base.Message):
         'subtask_id'
     ] + base.Message.__slots__
 
-    @base.verify_slot('direction', DIRECTION)
     @base.verify_slot('state_update_id', str)
     @base.verify_slot('task_id', str)
     @base.verify_slot('subtask_id', str)

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -637,7 +637,14 @@ class RejectReportComputedTask(TaskMessage, base.AbstractReasonMessage):
 
 @library.register(TASK_MSG_BASE + 31)
 class StateUpdate(base.Message):
-
+    """
+    Message used in state update communication between Provider and Requestor.
+    First Provider sends it to the Requestor (with DIRECTION=Call), then Requestor answers (with
+    DIRECTION=Response). The slot `data` contains arbitrary data, defined by app itself, and golem
+    is agnostic about it.
+    Example usage: provider sends progress update, requestor decides if the computation should be
+    aborted.
+    """
     @enum.unique
     class DIRECTION(datastructures.StringEnum):
         Call = enum.auto()

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'bitcoin',
         'cbor2==3.0.4',
         'coincurve>=7.1.0',
+        'eth-utils==1.0.3',
         'ethereum==1.6.1',
         'pyelliptic==1.5.10',
         'pytz',
@@ -44,7 +45,6 @@ setup(
         'semantic_version',
     ],
     tests_require=[
-        'eth-utils==0.7.4',
         'Faker==0.8.9',
         'factory-boy==2.9.2',
         'pycodestyle==2.4.0',

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -721,3 +721,7 @@ class StateUpdateTest(
         unittest.TestCase):
     MSG_CLASS = message.tasks.StateUpdate
     FACTORY = factories.tasks.StateUpdateFactory
+
+    def test_direction_type(self):
+        msg = self.FACTORY()
+        assert(isinstance(msg.direction, StateUpdateTest.MSG_CLASS.DIRECTION))

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -4,6 +4,7 @@ import time
 import unittest
 import unittest.mock as mock
 
+from eth_utils import is_checksum_address, to_checksum_address
 from ethereum.utils import sha3
 import factory
 
@@ -173,14 +174,16 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
         provider_public_key = decode_hex(msg.provider_ethereum_public_key)
 
         self.assertEqual(msg.provider_ethereum_address,
-                         '0x' + sha3(provider_public_key)[12:].hex())
+                         to_checksum_address(
+                             '0x' + sha3(provider_public_key)[12:].hex()))
 
     def test_ethereum_address_requestor(self):
         msg = factories.tasks.TaskToComputeFactory()
         requestor_public_key = decode_hex(msg.requestor_ethereum_public_key)
 
         self.assertEqual(msg.requestor_ethereum_address,
-                         '0x' + sha3(requestor_public_key)[12:].hex())
+                         to_checksum_address(
+                             '0x' + sha3(requestor_public_key)[12:].hex()))
 
     def test_task_id(self):
         self.assertEqual(self.msg.task_id,
@@ -206,7 +209,20 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
         with self.assertRaises(exceptions.FieldError):
             helpers.dump_and_load(ttc)
 
-    # pylint:disable=protected-access
+
+class TaskToComputeEthereumAddressChecksum(unittest.TestCase):
+    def test_requestor_ethereum_address_checksum(self):
+        ttc = factories.tasks.TaskToComputeFactory()
+        self.assertTrue(ttc.requestor_ethereum_public_key)
+        self.assertTrue(is_checksum_address(ttc.requestor_ethereum_address))
+
+    def test_provider_ethereum_address_checksum(self):
+        ttc = factories.tasks.TaskToComputeFactory()
+        self.assertTrue(ttc.provider_ethereum_public_key)
+        self.assertTrue(is_checksum_address(ttc.provider_ethereum_address))
+
+
+# pylint:disable=protected-access
 
 
 class TaskToComputeEthsigTest(unittest.TestCase):
@@ -273,7 +289,8 @@ class TaskToComputeEthsigTest(unittest.TestCase):
         self.assertTrue(msg2._ethsig)
         self.assertTrue(msg2.verify_ethsig())
 
-    # pylint:enable=protected-access
+
+# pylint:enable=protected-access
 
 
 class TaskToComputeEthsigFactory(unittest.TestCase):

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -652,3 +652,11 @@ class TaskFailureTest(
     MSG_CLASS = message.tasks.TaskFailure
     FACTORY = factories.tasks.TaskFailureFactory
     TASK_ID_PROVIDER = 'task_to_compute'
+
+
+class StateUpdateTest(
+        mixins.RegisteredMessageTestMixin,
+        mixins.SerializationMixin,
+        unittest.TestCase):
+    MSG_CLASS = message.tasks.StateUpdate
+    FACTORY = factories.tasks.StateUpdateFactory


### PR DESCRIPTION
This PR introduces new message type: `StateUpdate`. It is used to wrap Provider-Requestor communication during subtask execution. `data` field content is task-specific and golem is agnostic about it.
   