### PR TITLE
Verify subtask_id and task_id

### DIFF
--- a/golem_messages/factories/helpers.py
+++ b/golem_messages/factories/helpers.py
@@ -1,11 +1,18 @@
 # pylint: disable=too-few-public-methods
 import typing
+import uuid
+
 import factory
+import faker
 
 from golem_messages import datastructures
+from golem_messages import idgenerator
 
 if typing.TYPE_CHECKING:
     from golem_messages.message.base import Message  # noqa pylint:disable=unused-import
+
+
+fake = faker.Faker()
 
 
 def override_timestamp(
@@ -58,6 +65,22 @@ def optional_subfactory(field: str, object_factory: factory.Factory):
             call_subfactory(object_factory, create, extracted, **kwargs)
         )
     return factory.post_generation(_subfactory)
+
+
+def fake_golem_uuid(node_id: str) -> str:
+    random_uuid: uuid.UUID = uuid.UUID(fake.uuid4())
+    id_ = uuid.UUID(
+        # https://docs.python.org/3/library/uuid.html#uuid.UUID.fields
+        fields=(
+            random_uuid.time_low,
+            random_uuid.time_mid,
+            random_uuid.time_hi_version,
+            random_uuid.clock_seq_hi_variant,
+            random_uuid.clock_seq_low,
+            idgenerator.hexseed_to_node(node_id),
+        ),
+    )
+    return str(id_)
 
 
 class MessageFactory(factory.Factory):

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -92,6 +92,17 @@ class TaskToComputeFactory(helpers.MessageFactory):
     # pylint: disable=no-self-argument,attribute-defined-outside-init
 
     @factory.post_generation
+    def ctd_task_and_subtask_id(
+            ttc: tasks.TaskToCompute, _, __,
+    ):
+        ttc.compute_task_def['task_id'] = helpers.fake_golem_uuid(  # noqa pylint: disable=unsupported-assignment-operation
+            node_id=ttc.requestor_id,
+        )
+        ttc.compute_task_def['subtask_id'] = helpers.fake_golem_uuid(  # noqa pylint: disable=unsupported-assignment-operation
+            node_id=ttc.requestor_id,
+        )
+
+    @factory.post_generation
     def ethsig(
             ttc: tasks.TaskToCompute, _, __,
             privkey: typing.Optional[bytes] = None,

--- a/golem_messages/idgenerator.py
+++ b/golem_messages/idgenerator.py
@@ -1,21 +1,28 @@
 import uuid
 
+from . import utils
+
 
 SEED_LEN = 6
 
 
 def generate_id(seed: bytes) -> str:
     """
-    seeds top 48 bits from given seed as node in generated uuid1
+    seeds last 48 bits from given seed as node in generated uuid1
     :param bytes seed: for example `KeysAuth.public_key`
     :returns: string uuid1 based on timestamp and given seed
     """
     return str(uuid.uuid1(node=seed_to_node(seed)))
 
 
+def generate_id_from_hex(hexseed: str) -> str:
+    seed = utils.decode_hex(hexseed)
+    return generate_id(seed)
+
+
 def generate_new_id_from_id(id_: str) -> str:
     """
-    seeds low 48 bits from id_ as node in generated uuid1
+    seeds last 48 bits from id_ as node in generated uuid1
     :returns: uuid1 based on timestamp and id_
     """
     from_uuid = uuid.UUID(id_)
@@ -30,5 +37,15 @@ def check_id_seed(id_: str, seed: bytes) -> bool:
         return False
 
 
+def check_id_hexseed(id_: str, hexseed: str) -> bool:
+    seed = utils.decode_hex(hexseed)
+    return check_id_seed(id_, seed)
+
+
 def seed_to_node(seed: bytes) -> int:
     return int.from_bytes(seed[:SEED_LEN], 'big')
+
+
+def hexseed_to_node(hexseed: str) -> int:
+    seed = utils.decode_hex(hexseed)
+    return seed_to_node(seed)

--- a/golem_messages/idgenerator.py
+++ b/golem_messages/idgenerator.py
@@ -1,0 +1,34 @@
+import uuid
+
+
+SEED_LEN = 6
+
+
+def generate_id(seed: bytes) -> str:
+    """
+    seeds top 48 bits from given seed as node in generated uuid1
+    :param bytes seed: for example `KeysAuth.public_key`
+    :returns: string uuid1 based on timestamp and given seed
+    """
+    return str(uuid.uuid1(node=seed_to_node(seed)))
+
+
+def generate_new_id_from_id(id_: str) -> str:
+    """
+    seeds low 48 bits from id_ as node in generated uuid1
+    :returns: uuid1 based on timestamp and id_
+    """
+    from_uuid = uuid.UUID(id_)
+    return str(uuid.uuid1(node=from_uuid.node))
+
+
+def check_id_seed(id_: str, seed: bytes) -> bool:
+    try:
+        checked_uuid = uuid.UUID(id_)
+        return seed_to_node(seed) == checked_uuid.node
+    except ValueError:
+        return False
+
+
+def seed_to_node(seed: bytes) -> int:
+    return int.from_bytes(seed[:SEED_LEN], 'big')

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -3,6 +3,7 @@ import calendar
 import time
 import unittest
 import unittest.mock as mock
+import uuid
 
 from eth_utils import is_checksum_address, to_checksum_address
 from ethereum.utils import sha3
@@ -138,7 +139,7 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
         self.msg = self.FACTORY()
 
     def test_task_to_compute_basic(self):
-        ttc = factories.tasks.TaskToComputeFactory()
+        ttc = self.msg
         serialized = shortcuts.dump(ttc, None, None)
         msg = shortcuts.load(serialized, None, None)
         self.assertIsInstance(msg, message.tasks.TaskToCompute)
@@ -192,6 +193,22 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
     def test_subtask_id(self):
         self.assertEqual(self.msg.subtask_id,
                          self.msg.compute_task_def['subtask_id'])  # noqa pylint:disable=unsubscriptable-object
+
+    def _test_spoofed_id(self, key):
+        self.msg.compute_task_def[key] = str(uuid.uuid4())  # noqa pylint:disable=unsupported-assignment-operation
+
+        requestor_keys = cryptography.ECCx(None)
+        self.msg.requestor_ethereum_public_key = encode_hex(requestor_keys.raw_pubkey)
+        self.msg.generate_ethsig(private_key=requestor_keys.raw_privkey)
+        s = self.msg.serialize()
+        with self.assertRaises(exceptions.FieldError):
+            message.Message.deserialize(s, None)
+
+    def test_spoofed_task_id(self):
+        self._test_spoofed_id('task_id')
+
+    def test_spoofed_subtask_id(self):
+        self._test_spoofed_id('subtask_id')
 
     def test_past_deadline(self):
         now = calendar.timegm(time.gmtime())


### PR DESCRIPTION
Automagically reject all messages with invalid `node` part of `uuid1`.

fixes: #178 