### PR TITLE
Change TTC task_id and subtask_id post generation

### DIFF
--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -92,13 +92,28 @@ class TaskToComputeFactory(helpers.MessageFactory):
     # pylint: disable=no-self-argument,attribute-defined-outside-init
 
     @factory.post_generation
-    def ctd_task_and_subtask_id(
-            ttc: tasks.TaskToCompute, _, __,
+    def task_id(
+            ttc: tasks.TaskToCompute,
+            _create,
+            extracted,
     ):
-        ttc.compute_task_def['task_id'] = helpers.fake_golem_uuid(  # noqa pylint: disable=unsupported-assignment-operation
+        if ttc.compute_task_def is None:
+            return
+
+        ttc.compute_task_def['task_id'] = extracted or helpers.fake_golem_uuid(  # noqa pylint: disable=unsupported-assignment-operation
             node_id=ttc.requestor_id,
         )
-        ttc.compute_task_def['subtask_id'] = helpers.fake_golem_uuid(  # noqa pylint: disable=unsupported-assignment-operation
+
+    @factory.post_generation
+    def subtask_id(
+            ttc: tasks.TaskToCompute,
+            _create,
+            extracted,
+    ):
+        if ttc.compute_task_def is None:
+            return
+
+        ttc.compute_task_def['subtask_id'] = extracted or helpers.fake_golem_uuid(  # noqa pylint: disable=unsupported-assignment-operation
             node_id=ttc.requestor_id,
         )
 

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -129,11 +129,6 @@ class SubtaskResultsRejectedTest(mixins.RegisteredMessageTestMixin,
                               message.tasks.ReportComputedTask)
 
 
-def test_no_compute_task_def():
-    # Should not raise
-    factories.tasks.TaskToComputeFactory(compute_task_def=None)
-
-
 class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
                         mixins.SerializationMixin,
                         unittest.TestCase, ):
@@ -228,6 +223,10 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
         self.assertEqual(ttc.compute_task_def['task_id'], task_id)  # noqa pylint: disable=unsubscriptable-object
         self.assertEqual(ttc.subtask_id, subtask_id)
         self.assertEqual(ttc.compute_task_def['subtask_id'], subtask_id)  # noqa pylint: disable=unsubscriptable-object
+
+    def test_no_compute_task_def(self):
+        # Should not raise
+        factories.tasks.TaskToComputeFactory(compute_task_def=None)
 
     def test_past_deadline(self):
         now = calendar.timegm(time.gmtime())

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -129,6 +129,11 @@ class SubtaskResultsRejectedTest(mixins.RegisteredMessageTestMixin,
                               message.tasks.ReportComputedTask)
 
 
+def test_no_compute_task_def():
+    # Should not raise
+    factories.tasks.TaskToComputeFactory(compute_task_def=None)
+
+
 class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
                         mixins.SerializationMixin,
                         unittest.TestCase, ):
@@ -198,7 +203,9 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
         self.msg.compute_task_def[key] = str(uuid.uuid4())  # noqa pylint:disable=unsupported-assignment-operation
 
         requestor_keys = cryptography.ECCx(None)
-        self.msg.requestor_ethereum_public_key = encode_hex(requestor_keys.raw_pubkey)
+        self.msg.requestor_ethereum_public_key = encode_hex(
+            requestor_keys.raw_pubkey,
+        )
         self.msg.generate_ethsig(private_key=requestor_keys.raw_privkey)
         s = self.msg.serialize()
         with self.assertRaises(exceptions.FieldError):
@@ -209,6 +216,18 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
 
     def test_spoofed_subtask_id(self):
         self._test_spoofed_id('subtask_id')
+
+    def test_golem_id_shortcut(self):
+        task_id = 'tid'
+        subtask_id = 'sid'
+        ttc = factories.tasks.TaskToComputeFactory(
+            task_id=task_id,
+            subtask_id=subtask_id,
+        )
+        self.assertEqual(ttc.task_id, task_id)
+        self.assertEqual(ttc.compute_task_def['task_id'], task_id)  # noqa pylint: disable=unsubscriptable-object
+        self.assertEqual(ttc.subtask_id, subtask_id)
+        self.assertEqual(ttc.compute_task_def['subtask_id'], subtask_id)  # noqa pylint: disable=unsubscriptable-object
 
     def test_past_deadline(self):
         now = calendar.timegm(time.gmtime())
@@ -452,6 +471,7 @@ class AckReportComputedTaskTestCase(
         self.assertTrue(
             arct.validate_ownership(
                 concent_public_key=concent_keys.raw_pubkey))
+
 
 class RejectReportComputedTaskTestCase(
         mixins.RegisteredMessageTestMixin,


### PR DESCRIPTION
It's now possible to pass `task_id` and `subtask_id` values to factory post generators.