### PR TITLE
Change price field in TaskToCompute

### DIFF
--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -27,6 +27,7 @@ class WantToComputeTaskFactory(helpers.MessageFactory):
         'provider_public_key'
     )
     task_header = factory.SubFactory(TaskHeaderFactory)
+    price = factory.Faker('random_int', min=1 << 20, max=10 << 20)
 
 
 class CTDBlenderExtraDataFactory(factory.DictFactory):
@@ -72,7 +73,6 @@ class TaskToComputeFactory(helpers.MessageFactory):
     want_to_compute_task = factory.SubFactory(WantToComputeTaskFactory)
     package_hash = factory.LazyFunction(lambda: 'sha1:' + faker.Faker().sha1())
     size = factory.Faker('random_int', min=1 << 20, max=10 << 20)
-    price = factory.Faker('random_int', min=1 << 20, max=10 << 20)
 
     @classmethod
     def with_signed_nested_messages(

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -292,7 +292,6 @@ class TaskToCompute(ConcentEnabled, TaskMessage):
         'package_hash',  # the hash of the package (resources) zip file
         'size',  # the size of the resources zip file
         'concent_enabled',
-        'price',  # total subtask price computed as `price * subtask_timeout`
         'ethsig'
     ] + base.Message.__slots__
 
@@ -314,11 +313,17 @@ class TaskToCompute(ConcentEnabled, TaskMessage):
     def provider_ethereum_address(self):
         return self.want_to_compute_task.provider_ethereum_address
 
+    @property
+    def price(self):
+        price = self.want_to_compute_task.price
+        timeout = self.want_to_compute_task.task_header.subtask_timeout
+        return (price * timeout + 3599) // 3600
+
     def deserialize_slot(self, key, value):
         value = super().deserialize_slot(key, value)
         if key == 'compute_task_def':
             value = ComputeTaskDef(value)
-        if key in ('price', 'size'):
+        if key == 'size':
             validators.validate_integer(
                 field_name=key,
                 value=value,

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -520,25 +520,6 @@ class TaskToComputeEthsigFactory(unittest.TestCase):
             )
 
 
-class PriceTaskToComputeTestCase(unittest.TestCase):
-    def setUp(self):
-        self.factory = factories.tasks.TaskToComputeFactory
-
-    def test_valid_price_value(self):
-        price = 1994
-        msg = self.factory(price=price)
-        s = msg.serialize()
-        msg2 = message.Message.deserialize(s, None)
-        self.assertEqual(msg2.price, price)
-
-    def test_invalid_price_value(self):
-        price = '1994'
-        msg = self.factory(price=price)
-        s = msg.serialize()
-        with self.assertRaises(exceptions.FieldError):
-            message.Message.deserialize(s, None)
-
-
 class ReportComputedTaskTest(mixins.RegisteredMessageTestMixin,
                              mixins.SerializationMixin,
                              unittest.TestCase):

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -520,6 +520,19 @@ class TaskToComputeEthsigFactory(unittest.TestCase):
             )
 
 
+class PriceTaskToComputeTestCase(unittest.TestCase):
+    def setUp(self):
+        self.factory = factories.tasks.TaskToComputeFactory
+
+    def test_price_property(self):
+        price = 10
+        timeout = 7200
+        msg = self.factory()
+        msg.want_to_compute_task.price = price
+        msg.want_to_compute_task.task_header.subtask_timeout = timeout
+        self.assertEqual(msg.price, 20)
+
+
 class ReportComputedTaskTest(mixins.RegisteredMessageTestMixin,
                              mixins.SerializationMixin,
                              unittest.TestCase):


### PR DESCRIPTION
Use value from `WantToComputeTask` and change its meaning to total amount to be paid, instead of rate per hour.