### PR TITLE
Fixed Node serialization in Peer

### DIFF
--- a/golem_messages/datastructures/p2p.py
+++ b/golem_messages/datastructures/p2p.py
@@ -134,6 +134,8 @@ class Peer(datastructures.ValidatingDict, datastructures.FrozenDict):
             )
 
     def serialize(self) -> dict:
-        serialized = copy.deepcopy(self)
-        serialized['node'] = serialized['node'].to_dict()
-        return serialized
+        return {
+            'address': self['address'],
+            'port': self['port'],
+            'node': self['node'].to_dict()
+        }

--- a/golem_messages/datastructures/p2p.py
+++ b/golem_messages/datastructures/p2p.py
@@ -1,4 +1,3 @@
-import copy
 import functools
 import logging
 

--- a/golem_messages/datastructures/p2p.py
+++ b/golem_messages/datastructures/p2p.py
@@ -133,8 +133,6 @@ class Peer(datastructures.ValidatingDict, datastructures.FrozenDict):
             )
 
     def serialize(self) -> dict:
-        return {
-            'address': self['address'],
-            'port': self['port'],
-            'node': self['node'].to_dict()
-        }
+        serialized = dict(self)
+        serialized['node'] = serialized['node'].to_dict()
+        return serialized

--- a/tests/datastructures/test_p2p.py
+++ b/tests/datastructures/test_p2p.py
@@ -4,6 +4,7 @@ import faker
 
 from golem_messages import exceptions
 from golem_messages.factories.datastructures import p2p as dt_p2p_factory
+from golem_messages import message
 
 
 fake = faker.Faker()
@@ -91,3 +92,11 @@ class TestPeer(unittest.TestCase):
     def test_address_none(self):
         with self.assertRaises(exceptions.FieldError):
             self.peer['address'] = None
+
+    def test_peers_serialization(self):
+        peers = [dt_p2p_factory.Peer()]
+        msg = message.p2p.Peers(peers=peers)
+
+        serialized = msg.serialize()
+
+        self.assertIsInstance(serialized, bytes)

--- a/tests/datastructures/test_p2p.py
+++ b/tests/datastructures/test_p2p.py
@@ -94,7 +94,7 @@ class TestPeer(unittest.TestCase):
             self.peer['address'] = None
 
     def test_peers_serialization(self):
-        peers = [dt_p2p_factory.Peer()]
+        peers = [self.peer]
         msg = message.p2p.Peers(peers=peers)
 
         serialized = msg.serialize()

--- a/tests/message/test_messages.py
+++ b/tests/message/test_messages.py
@@ -362,3 +362,11 @@ class MessagesTestCase(unittest.TestCase):
             )
         for i in range(test_cases):
             self.assertEqual(msg_l.remove_tasks[i].task_id, task_ids[i])
+
+    def test_peers_serialization(self):
+        peers = [dt_p2p_factory.Peer(), ]
+        msg = message.p2p.Peers(peers=peers)
+
+        serialized = msg.serialize()
+
+        self.assertIsInstance(serialized, bytes)

--- a/tests/message/test_messages.py
+++ b/tests/message/test_messages.py
@@ -362,11 +362,3 @@ class MessagesTestCase(unittest.TestCase):
             )
         for i in range(test_cases):
             self.assertEqual(msg_l.remove_tasks[i].task_id, task_ids[i])
-
-    def test_peers_serialization(self):
-        peers = [dt_p2p_factory.Peer(), ]
-        msg = message.p2p.Peers(peers=peers)
-
-        serialized = msg.serialize()
-
-        self.assertIsInstance(serialized, bytes)


### PR DESCRIPTION
Fixes: [#3705](https://github.com/golemfactory/golem/issues/3705)

When serializing Peer instances, the inner Node was being converted to
a dict and put back under the same key. Due to Peer's custom
__setitem__ implementation, the dict was converted back into a Node object upon insertion.
This caused later CBOR serialization to fail.