### PR TITLE
Remove GetResource and ResourceList message

### DIFF
--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -58,6 +58,7 @@ class ComputeTaskDefFactory(factory.DictFactory):
         int(datetime.timedelta(days=1).total_seconds()))
     src_code = factory.Faker('text')
     extra_data = factory.SubFactory(CTDBlenderExtraDataFactory)
+    resources = factory.List([factory.Faker('uuid4')])
 
 
 class TaskToComputeFactory(helpers.MessageFactory):

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -79,6 +79,7 @@ class TaskToComputeFactory(helpers.MessageFactory):
     package_hash = factory.LazyFunction(lambda: 'sha1:' + faker.Faker().sha1())
     size = factory.Faker('random_int', min=1 << 20, max=10 << 20)
     price = factory.Faker('random_int', min=1 << 20, max=10 << 20)
+    resources_options = factory.Faker('uuid4')
 
     @classmethod
     def past_deadline(cls, *args, **kwargs):

--- a/golem_messages/message/__init__.py
+++ b/golem_messages/message/__init__.py
@@ -50,13 +50,11 @@ from golem_messages.message.tasks import StartSessionResponse  # noqa
 from golem_messages.message.tasks import WaitingForResults  # noqa
 from golem_messages.message.tasks import SubtaskPayment  # noqa
 from golem_messages.message.tasks import SubtaskPaymentRequest  # noqa
-from golem_messages.message.tasks import GetResource  # noqa
 from golem_messages.message.resources import PushResource  # noqa
 from golem_messages.message.resources import HasResource  # noqa
 from golem_messages.message.resources import WantsResource  # noqa
 from golem_messages.message.resources import PullResource  # noqa
 from golem_messages.message.resources import PullAnswer  # noqa
-from golem_messages.message.resources import ResourceList  # noqa
 from golem_messages.message.resources import ResourceHandshakeStart  # noqa
 from golem_messages.message.resources import ResourceHandshakeNonce  # noqa
 from golem_messages.message.resources import ResourceHandshakeVerdict  # noqa

--- a/golem_messages/message/resources.py
+++ b/golem_messages/message/resources.py
@@ -54,17 +54,6 @@ class PullAnswer(base.Message):
     ] + base.Message.__slots__
 
 
-@library.register(RESOURCE_MSG_BASE + 7)
-class ResourceList(base.Message):
-    """Message with resource request
-    :param str resources: resource list
-    """
-    __slots__ = [
-        'resources',
-        'options'
-    ] + base.Message.__slots__
-
-
 @library.register(RESOURCE_MSG_BASE + 8)
 class ResourceHandshakeStart(base.Message):
     __slots__ = [

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -32,6 +32,7 @@ class ComputeTaskDef(datastructures.ValidatingDict, datastructures.FrozenDict):
         'short_description': '',
         'performance': 0,
         'docker_images': None,
+        'resources': [],
     }
 
     validate_task_id = functools.partial(

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -443,15 +443,6 @@ class ReportComputedTask(TaskMessage):
     ] + base.Message.__slots__
 
 
-@library.register(TASK_MSG_BASE + 8)
-class GetResource(base.Message):
-    """Request a resource for a given task"""
-    __slots__ = [
-        'task_id',
-        'resource_header'
-    ] + base.Message.__slots__
-
-
 @library.register(TASK_MSG_BASE + 10)
 class SubtaskResultsAccepted(TaskMessage):
     """

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -280,6 +280,7 @@ class TaskToCompute(ConcentEnabled, TaskMessage):
         'size',  # the size of the resources zip file
         'concent_enabled',
         'price',  # total subtask price computed as `price * subtask_timeout`
+        'resources_options',
         'ethsig'
     ] + base.Message.__slots__
 

--- a/tests/message/test_messages.py
+++ b/tests/message/test_messages.py
@@ -225,19 +225,6 @@ class MessagesTestCase(unittest.TestCase):
         ]
         self.assertEqual(expected, msg.slots())
 
-    def test_message_get_resource(self):
-        task_id = 'test-ti-{}'.format(uuid.uuid4())
-        resource_header = 'test-rh-{}'.format(uuid.uuid4())
-        msg = message.GetResource(
-            task_id=task_id,
-            resource_header=resource_header
-        )
-        expected = [
-            ['task_id', task_id],
-            ['resource_header', resource_header],
-        ]
-        self.assertEqual(expected, msg.slots())
-
     def test_message_task_failure(self):
         ttc = factories.tasks.TaskToComputeFactory()
         err = (
@@ -295,16 +282,6 @@ class MessagesTestCase(unittest.TestCase):
                 ['has_resource', has_resource],
             ]
             self.assertEqual(expected, msg.slots())
-
-    def test_message_resource_list(self):
-        resources = 'test-rs-{}'.format(uuid.uuid4())
-        options = 'test-clientoptions-{}'.format(uuid.uuid4())
-        msg = message.ResourceList(resources=resources, options=options)
-        expected = [
-            ['resources', resources],
-            ['options', options],
-        ]
-        self.assertEqual(expected, msg.slots())
 
     def test_message_remove_task_container(self):
         test_cases = 10

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -308,6 +308,10 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
         with self.assertRaises(exceptions.FieldError):
             helpers.dump_and_load(ttc)
 
+    def test_resources_options(self):
+        ttc = factories.tasks.TaskToComputeFactory()
+        self.assertTrue(hasattr(ttc, 'resources_options'))
+
 
 class TaskToComputeEthereumAddressChecksum(unittest.TestCase):
     def test_requestor_ethereum_address_checksum(self):

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -109,10 +109,6 @@ class ComputeTaskDefTestCase(unittest.TestCase):
         self.assertTrue(extra_data['frames'])
         self.assertTrue(extra_data['output_format'])
 
-    def test_has_resources(self):
-        ctd = message.ComputeTaskDef()
-        self.assertIsInstance(ctd['resources'], list)
-
 
 class SubtaskResultsAcceptedTest(mixins.RegisteredMessageTestMixin,
                                  mixins.SerializationMixin,
@@ -351,10 +347,6 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
         ttc = factories.tasks.TaskToComputeFactory(size=None)
         with self.assertRaises(exceptions.FieldError):
             helpers.dump_and_load(ttc)
-
-    def test_resources_options(self):
-        ttc = factories.tasks.TaskToComputeFactory()
-        self.assertTrue(hasattr(ttc, 'resources_options'))
 
 
 class TaskToComputeSignedChainFactory(unittest.TestCase):

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -101,6 +101,10 @@ class ComputeTaskDefTestCase(unittest.TestCase):
         self.assertTrue(extra_data['frames'])
         self.assertTrue(extra_data['output_format'])
 
+    def test_has_resources(self):
+        ctd = message.ComputeTaskDef()
+        self.assertIsInstance(ctd.resources, list)
+
 
 class SubtaskResultsAcceptedTest(mixins.RegisteredMessageTestMixin,
                                  mixins.SerializationMixin,

--- a/tests/message/test_tasks.py
+++ b/tests/message/test_tasks.py
@@ -103,7 +103,7 @@ class ComputeTaskDefTestCase(unittest.TestCase):
 
     def test_has_resources(self):
         ctd = message.ComputeTaskDef()
-        self.assertIsInstance(ctd.resources, list)
+        self.assertIsInstance(ctd['resources'], list)
 
 
 class SubtaskResultsAcceptedTest(mixins.RegisteredMessageTestMixin,


### PR DESCRIPTION
Information about resources should be included in ComputeTaskDef. Thanks to that we can:
1) Simplify the protocol
2) Add support for sending different resources for different subtasks, which will be necessary for future use cases. 