### PR TITLE
Remove short_description from ctd

### DIFF
--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -30,7 +30,6 @@ class ComputeTaskDef(datastructures.ValidatingDict, datastructures.FrozenDict):
         'deadline': 0,
         'src_code': '',
         'extra_data': {},  # safe because of copy in parent.__missing__()
-        'short_description': '',
         'performance': 0,
         'docker_images': None,
     }


### PR DESCRIPTION
It's not used in Golem anymore