### PR TITLE
Remove resource_size from TaskHeader

### DIFF
--- a/golem_messages/datastructures/tasks.py
+++ b/golem_messages/datastructures/tasks.py
@@ -64,7 +64,6 @@ class TaskHeader(datastructures.Container):
                 fail_msg="Subtask timeout is less than 0",
             ),
         ),
-        'resource_size': (validators.validate_integer, ),
         # environment.get_id()
         'environment': (validators.validate_varchar128, ),
         'min_version': (validators.validate_version, ),

--- a/golem_messages/factories/datastructures/tasks.py
+++ b/golem_messages/factories/datastructures/tasks.py
@@ -34,7 +34,6 @@ class TaskHeaderFactory(factory.Factory):
     )
     deadline = factory.LazyFunction(lambda: int(time.time()) + 3600)
     subtask_timeout = factory.Faker('random_int', min=60, max=600)
-    resource_size = factory.Faker('random_int', max=4096)
     environment = "DEFAULT"
     min_version = factory.LazyFunction(helpers.fake_version)
     estimated_memory = factory.Faker('random_int', max=4096)

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -74,7 +74,7 @@ class TaskToComputeFactory(helpers.MessageFactory):
     package_hash = factory.LazyFunction(lambda: 'sha1:' + faker.Faker().sha1())
     size = factory.Faker('random_int', min=1 << 20, max=10 << 20)
     price = factory.Faker('random_int', min=1 << 20, max=10 << 20)
-    resources_options = factory.Faker('uuid4')
+    resources_options = None
 
     @classmethod
     def with_signed_nested_messages(

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -590,6 +590,7 @@ class CannotComputeTask(TaskMessage, base.AbstractReasonMessage):
         InsufficientDeposit = enum.auto()  # GNTB deposit too low
         TooShortDeposit = enum.auto()  # GNTB deposit has too short lock
         OfferCancelled = enum.auto()
+        ResourcesTooBig = enum.auto()
 
 
 @library.register(TASK_MSG_BASE + 27)

--- a/tests/datastructures/test_tasks.py
+++ b/tests/datastructures/test_tasks.py
@@ -28,7 +28,6 @@ class TestTaskHeader(unittest.TestCase):
             "subtasks_count": 21,
             "max_price": 10,
             "min_version": "0.19.0",
-            "resource_size": 0,
             "estimated_memory": 0,
             "timestamp": int(time.time()),
         }


### PR DESCRIPTION
If we want to make possible to add different resources for different subtasks we cannot send just one size in the TaskHeader. This PR:

* Removes resource_size from TaskHeader
* Removes providers check of resource size at the task selection state
* Provider may refuse to compute tasks with too big resources after getting TaskToCompute with specific resource size.
* Taskkeeper keeping time is updated after TaskToCompute with proper resource size is sent.

Golem PR: https://github.com/golemfactory/golem/pull/3917