### PR TITLE
Remove node_name from messages

### DIFF
--- a/golem_messages/factories/base.py
+++ b/golem_messages/factories/base.py
@@ -2,6 +2,7 @@
 import factory
 
 from golem_messages.message import base
+from golem_messages.factories import p2p as p2p_factories
 from . import helpers
 
 
@@ -11,4 +12,4 @@ class HelloFactory(helpers.MessageFactory):
 
     rand_val = factory.Faker("pyint")
     proto_id = factory.Faker("pyint")
-    node_name = factory.Faker("name")
+    node_info = factory.SubFactory(p2p_factories.Node)

--- a/golem_messages/factories/datastructures/p2p.py
+++ b/golem_messages/factories/datastructures/p2p.py
@@ -11,6 +11,7 @@ class Node(factory.Factory):
 
     # considered as difficult by `keysauth.is_pubkey_difficult` with level 10
     key = '00adbeef' + 'deadbeef' * 15
+    node_name = factory.Faker('name')
 
 
 class Peer(factory.DictFactory):

--- a/golem_messages/factories/tasks.py
+++ b/golem_messages/factories/tasks.py
@@ -20,7 +20,6 @@ class WantToComputeTaskFactory(helpers.MessageFactory):
     class Meta:
         model = tasks.WantToComputeTask
 
-    node_name = factory.Faker('name')
     provider_public_key = factory.LazyFunction(
         lambda: encode_key_id(cryptography.ECCx(None).raw_pubkey))
     provider_ethereum_public_key = factory.SelfAttribute(
@@ -252,7 +251,6 @@ class ReportComputedTaskFactory(helpers.MessageFactory):
     class Meta:
         model = tasks.ReportComputedTask
 
-    node_name = factory.Faker('name')
     address = factory.Faker('ipv4')
     port = factory.Faker('pyint')
     key_id = factory.Faker('binary', length=64)

--- a/golem_messages/message/base.py
+++ b/golem_messages/message/base.py
@@ -632,7 +632,6 @@ class Hello(dt_p2p.NodeSlotMixin, Message):
     __slots__ = [
         'rand_val',
         'proto_id',
-        'node_name',
         'node_info',
         'port',
         'client_ver',

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -241,7 +241,6 @@ class WantToComputeTask(ConcentEnabled, base.Message):
 
     """
     __slots__ = [
-        'node_name',          # Provider's node name
         'perf_index',         # Provider's performance; a benchmark result
         'max_resource_size',  # P's storage size available for computation
         'max_memory_size',    # P's RAM
@@ -500,7 +499,6 @@ class ReportComputedTask(TaskMessage):
     }
 
     __slots__ = [
-        'node_name',
         'address',
         'node_info',
         'port',

--- a/tests/message/test_messages.py
+++ b/tests/message/test_messages.py
@@ -27,23 +27,23 @@ class InitializationTestCase(unittest.TestCase):
             self.assertIsNone(getattr(msg, key))
 
     def test_kwarg(self):
-        node_name = 'Tuż nad Bugiem, z lewej strony,'
-        msg = message.Hello(node_name=node_name)
-        self.assertEqual(msg.node_name, node_name)
+        challenge = 'Tuż nad Bugiem, z lewej strony,'
+        msg = message.Hello(challenge=challenge)
+        self.assertEqual(msg.challenge, challenge)
 
     def test_slot(self):
-        node_name = 'Tuż nad Bugiem, z lewej strony,'
-        msg = message.Hello(slots=[('node_name', node_name), ])
-        self.assertEqual(msg.node_name, node_name)
+        challenge = 'Tuż nad Bugiem, z lewej strony,'
+        msg = message.Hello(slots=[('challenge', challenge), ])
+        self.assertEqual(msg.challenge, challenge)
 
     def test_kwarg_and_slot(self):
-        node_name_kwarg = 'Tuż nad Bugiem, z lewej strony,'
-        node_name_slot = 'Stoi wielki bór zielony.'
+        challenge_kwarg = 'Tuż nad Bugiem, z lewej strony,'
+        challenge_slot = 'Stoi wielki bór zielony.'
         msg = message.Hello(
-            node_name=node_name_kwarg,
-            slots=[('node_name', node_name_slot), ],
+            challenge=challenge_kwarg,
+            slots=[('challenge', challenge_slot), ],
         )
-        self.assertEqual(msg.node_name, node_name_slot)
+        self.assertEqual(msg.challenge, challenge_slot)
 
 
 class MessagesTestCase(unittest.TestCase):


### PR DESCRIPTION
`node_name` field is not needed in messages. When it's needed it's contained in `datastructures.p2p.Node`.

fixes: #263 
fixes: #322 