### PR TITLE
Added envrionment prerequisites dict to TaskHeader

### DIFF
--- a/golem_messages/datastructures/tasks.py
+++ b/golem_messages/datastructures/tasks.py
@@ -57,6 +57,7 @@ class TaskHeader(datastructures.Container):
         ),
         # environment.get_id()
         'environment': (validators.validate_varchar128, ),
+        'environment_prerequisites': (validators.validate_dict, ),
         'min_version': (validators.validate_version, ),
         'estimated_memory': (validators.validate_integer, ),
         # maximum price that this (requestor) node


### PR DESCRIPTION
This field is needed for the new refactored Golem environments.