### PR TITLE
Added stats field to ReportComputedTask

### DIFF
--- a/golem_messages/datastructures/stats.py
+++ b/golem_messages/datastructures/stats.py
@@ -1,0 +1,210 @@
+import functools
+from typing import Optional
+
+from golem_messages import datastructures
+from golem_messages import validators
+
+
+class BlockIoEntry(datastructures.FrozenDict):
+
+    ITEMS = {
+        'major': 0,
+        'minor': 0,
+        'op': None,
+        'value': 0,
+    }
+
+
+validate_block_stat_entry = functools.partial(
+    validators.fail_unless,
+    check=lambda x: isinstance(x, (dict, BlockIoEntry)),
+    fail_msg="Should be a dict or BlockIoEntry",
+)
+
+
+class BlockIoStats(datastructures.Container):
+    """ These stats refer to the number of bytes transferred to and from the
+        block device. """
+
+    slot_names = ['io_merged_recursive', 'io_queue_recursive',
+                  'io_service_bytes_recursive', 'io_service_time_recursive',
+                  'io_serviced_recursive', 'io_time_recursive',
+                  'io_wait_time_recursive', 'sectors_recursive']
+
+    __slots__ = {slot: (validate_block_stat_entry, ) for slot in slot_names}
+
+
+class CpuUsage(datastructures.FrozenDict):
+    """ Stats on the total CPU usage for the subtask. All values are in
+        nanoseconds. """
+
+    ITEMS = {
+        'percpu_usage': [],
+        'total_usage': 0,
+        'usage_in_kernelmode': 0,
+        'usage_in_usermode': 0,
+    }
+
+
+class ThrottlingData(datastructures.FrozenDict):
+
+    ITEMS = {
+        # Number of periods with throttling active
+        'periods': 0,
+        # Number of periods with throttling limit reached
+        'throttled_periods': 0,
+        # Total time when throttling was active (in nanoseconds)
+        'throttled_time': 0
+    }
+
+
+class CpuStats(datastructures.Container):
+    """ Aggregate CPU statistics for a given subtask. Both fields are
+        considered optional. """
+
+    __slots__ = {
+        'cpu_usage': (
+            validators.validate_dict,
+        ),
+        'throttling_data': (
+            validators.validate_dict,
+        ),
+    }
+
+    @classmethod
+    def deserialize_cpu_usage(cls, value: dict) -> Optional[CpuUsage]:
+        return CpuUsage(**value) if value else None
+
+    @classmethod
+    def deserialize_throttling_data(cls, value: dict) \
+            -> Optional[ThrottlingData]:
+        return ThrottlingData(**value) if value else None
+
+    @classmethod
+    def serialize_cpu_usage(cls, value: CpuUsage) -> Optional[CpuUsage]:
+        return value if value else None
+
+    @classmethod
+    def serialize_throttling_data(cls, value: ThrottlingData) \
+            -> Optional[ThrottlingData]:
+        return value if value else None
+
+
+class MemoryData(datastructures.FrozenDict):
+
+    ITEMS = {
+        'failcnt': 0,
+        'limit': 0,
+        'max_usage': 0,
+        'usage': 0,
+    }
+
+
+validate_memory_data = functools.partial(
+    validators.fail_unless,
+    check=lambda x: isinstance(x, (dict, MemoryData)),
+    fail_msg="Should be a dict or MemoryData",
+)
+
+
+class MemoryStats(datastructures.Container):
+
+    memory_data_slots = ['kernel_tcp_usage', 'kernel_usage', 'swap_usage',
+                         'usage']
+
+    __slots__ = {slot: (validate_memory_data, ) for slot in memory_data_slots}
+
+    __slots__.update({
+        'cache': (
+            validators.validate_integer,
+        ),
+        'stats': (
+            validators.validate_dict,
+        ),
+        'use_hierarchy': (
+            validators.validate_boolean,
+        ),
+    })
+
+
+class PidStats(datastructures.Container):
+
+    __slots__ = {
+        'current': (
+            validators.validate_integer,
+        ),
+        'limit': (
+            validators.validate_integer,
+        )
+    }
+
+
+class ProviderStats(datastructures.Container):
+    """ Container for statistics on resource usage gathered on the provider's
+        side. These are part of the ReportComputedTask message. All fields are
+        considered optional (validators are there to indicate types and in case
+        we wanted to make some of the fields required in the future). Generally,
+        at least the CPU stats should be available in most cases. """
+
+    __slots__ = {
+        'blkio_stats': (
+            functools.partial(
+                validators.fail_unless,
+                check=lambda x: isinstance(x, (dict, BlockIoStats)),
+                fail_msg="Should be a dict or BlockIoStats",
+            ),
+        ),
+        'cpu_stats': (
+            functools.partial(
+                validators.fail_unless,
+                check=lambda x: isinstance(x, (dict, CpuStats)),
+                fail_msg="Should be a dict or CpuStats",
+            ),
+        ),
+        'memory_stats': (
+            functools.partial(
+                validators.fail_unless,
+                check=lambda x: isinstance(x, (dict, MemoryStats)),
+                fail_msg="Should be a dict or MemoryStats",
+            ),
+        ),
+        'pids_stats': (
+            functools.partial(
+                validators.fail_unless,
+                check=lambda x: isinstance(x, (dict, PidStats)),
+                fail_msg="Should be a dict or PidStats",
+            ),
+        ),
+    }
+
+    @classmethod
+    def deserialize_blkio_stats(cls, value: dict) -> Optional[BlockIoStats]:
+        return BlockIoStats(**value) if value else None
+
+    @classmethod
+    def deserialize_cpu_stats(cls, value: dict) -> Optional[CpuStats]:
+        return CpuStats(**value) if value else None
+
+    @classmethod
+    def deserialize_memory_stats(cls, value: dict) -> Optional[MemoryStats]:
+        return MemoryStats(**value) if value else None
+
+    @classmethod
+    def deserialize_pids_stats(cls, value: dict) -> Optional[PidStats]:
+        return PidStats(**value) if value else None
+
+    @classmethod
+    def serialize_blkio_stats(cls, value: BlockIoStats) -> Optional[dict]:
+        return value.to_dict() if value else None
+
+    @classmethod
+    def serialize_cpu_stats(cls, value: CpuStats) -> Optional[dict]:
+        return value.to_dict() if value else None
+
+    @classmethod
+    def serialize_memory_stats(cls, value: MemoryStats) -> Optional[dict]:
+        return value.to_dict() if value else None
+
+    @classmethod
+    def serialize_pids_stats(cls, value: PidStats) -> Optional[dict]:
+        return value.to_dict() if value else None

--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -8,8 +8,9 @@ from golem_messages import idgenerator
 from golem_messages import settings
 from golem_messages import validators
 from golem_messages.datastructures import promissory
-from golem_messages.datastructures.tasks import TaskHeader
 from golem_messages.datastructures.promissory import PromissoryNote
+from golem_messages.datastructures.stats import ProviderStats
+from golem_messages.datastructures.tasks import TaskHeader
 from golem_messages.register import library
 from golem_messages.utils import decode_hex, pubkey_to_address
 
@@ -502,7 +503,20 @@ class ReportComputedTask(TaskMessage):
                          # the result directly between the nodes
         'secret',
         'options',
+        'stats',
     ] + base.Message.__slots__
+
+    def serialize_slot(self, key, value):
+        if key == 'stats' and isinstance(value, ProviderStats):
+            return value.to_dict()
+
+        return super().serialize_slot(key, value)
+
+    def deserialize_slot(self, key, value):
+        if key == 'stats' and value is not None:
+            return ProviderStats(**value)
+
+        return super().deserialize_slot(key, value)
 
 
 @library.register(TASK_MSG_BASE + 10)

--- a/tests/datastructures/test_stats.py
+++ b/tests/datastructures/test_stats.py
@@ -1,0 +1,87 @@
+import unittest
+
+from golem_messages.datastructures import stats
+from golem_messages import exceptions
+
+
+class TestProviderStats(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stats_dict = {
+            'cpu_stats': {
+                'cpu_usage': {
+                    'total_usage': 210742887,
+                    'percpu_usage': [
+                        2294161, 4289803, 2629870, 13575808, 153013241, 4415022,
+                        5868137, 5475479, 3252549, 3329389, 7260411, 5347658
+                    ],
+                    'usage_in_kernelmode': 30000000,
+                    'usage_in_usermode': 150000000
+                },
+                'throttling_data': {}
+            },
+            'memory_stats': {
+                'usage': {
+                    'usage': 4554752,
+                    'max_usage': 7172096,
+                    'failcnt': 0,
+                    'limit': 9223372036854771712
+                },
+                'swap_usage': {},
+                'kernel_usage': {
+                    'usage': 2748416,
+                    'max_usage': 2818048,
+                    'failcnt': 0,
+                    'limit': 9223372036854771712
+                },
+                'kernel_tcp_usage': {},
+                'stats': {}
+            },
+            'pids_stats': {},
+            'blkio_stats': {
+                'io_merged_recursive': {
+                    'major': 1500,
+                    'minor': 0,
+                    'op': 'test',
+                    'value': 0
+                },
+                'sectors_recursive': {
+                    'major': 666,
+                    'minor': 0,
+                    'op': 'test',
+                    'value': 0
+                }
+            }
+        }
+
+    def test_deserialize(self):
+        stats.ProviderStats(**self.stats_dict)
+
+    def test_serialize(self):
+        deserialized = stats.ProviderStats(**self.stats_dict)
+        serialized = deserialized.to_dict()
+
+        self.assertIsNone(serialized['pids_stats'])
+        self.assertIsNone(serialized['cpu_stats']['throttling_data'])
+
+    def test_repr(self):
+        provider_stats = stats.ProviderStats(**self.stats_dict)
+        self.assertEqual(repr(provider_stats),
+                         '<ProviderStats: %r>' % provider_stats.to_dict())
+
+    def test_validate_cpu_stats_invalid_type(self):
+        self.stats_dict['cpu_stats'] = []
+
+        with self.assertRaisesRegex(
+            exceptions.FieldError,
+            r"^Should be a dict or CpuStats \[cpu_stats:\[\]\]$"
+        ):
+            stats.ProviderStats(**self.stats_dict)
+
+    def test_validate_memory_usage_invalid_type(self):
+        self.stats_dict['memory_stats']['usage'] = 'I should be a dict'
+
+        with self.assertRaisesRegex(
+            exceptions.FieldError,
+            r"^Should be a dict or MemoryData \[usage:'I should be a dict'\]"
+        ):
+            stats.ProviderStats(**self.stats_dict)


### PR DESCRIPTION
Part of: [#4526](https://github.com/golemfactory/golem/issues/4526)

The new field holds aggregate resource usage statistics collected while
running the given subtask by the provider. The structure for the field
comes from the way cgroups subsystems are organised (see: https://github.com/golemfactory/docker-cgroups-stats).