### PR TITLE
Add cpu_usage field to WTCT

### DIFF
--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -242,6 +242,7 @@ class WantToComputeTask(ConcentEnabled, base.Message):
     """
     __slots__ = [
         'perf_index',         # Provider's performance; a benchmark result
+        'cpu_usage',          # Provider's cpu usage; a benchmark result
         'max_resource_size',  # P's storage size available for computation
         'max_memory_size',    # P's RAM
         'price',              # Offered price per hour in GNT WEI (10e-18)
@@ -278,6 +279,15 @@ class WantToComputeTask(ConcentEnabled, base.Message):
     def deserialize_slot(self, key, value):
         if key == 'task_header' and value is not None:
             return TaskHeader(**value)
+
+        if key == 'cpu_usage' and value is not None:
+            validators.validate_integer(key, value)
+            if value < 0:
+                raise exceptions.FieldError(
+                    "Should be equal or greater than zero",
+                    field=key,
+                    value=value,
+                )
 
         value = super().deserialize_slot(key, value)
 

--- a/tests/message/tasks/test_want_to_compute_task.py
+++ b/tests/message/tasks/test_want_to_compute_task.py
@@ -93,3 +93,11 @@ class WantToComputeTaskTest(unittest.TestCase, mixins.SerializationMixin):
         wtct = self.FACTORY()
         self.assertIsNotNone(wtct.header)
         self.assertIsInstance(wtct.header, MessageHeader)
+
+    def test_cpu_usage_negative_integer(self):
+        wtct = message.tasks.WantToComputeTask(cpu_usage=-1)
+        serialized = shortcuts.dump(wtct, None, None)
+        with self.assertRaises(
+            exceptions.FieldError,
+        ):
+            shortcuts.load(serialized, None, None)


### PR DESCRIPTION
A change needed for usage market, providers need to report their benchmarks for specific environment ids. 

@jivan Is it as simple as that to add a field to message? 