### PR TITLE
Rename task_type to market_type and remove it from REQUIRED

### DIFF
--- a/golem_messages/constants.py
+++ b/golem_messages/constants.py
@@ -1,5 +1,6 @@
 import collections
 import datetime
+from enum import Enum
 
 from golem_messages import message
 
@@ -44,3 +45,8 @@ MSG_DELAYS = collections.defaultdict(
         message.concents.ForceReportComputedTask: (2 * MMTT + MAT),
     },
 )
+
+
+class MarketType(str, Enum):
+    BRASS_MARKET = "brass"
+    USAGE_MARKET = "usage"

--- a/golem_messages/constants.py
+++ b/golem_messages/constants.py
@@ -1,6 +1,5 @@
 import collections
 import datetime
-from enum import Enum
 
 from golem_messages import message
 
@@ -45,8 +44,3 @@ MSG_DELAYS = collections.defaultdict(
         message.concents.ForceReportComputedTask: (2 * MMTT + MAT),
     },
 )
-
-
-class MarketType(str, Enum):
-    BRASS_MARKET = "brass"
-    USAGE_MARKET = "usage"

--- a/golem_messages/datastructures/__init__.py
+++ b/golem_messages/datastructures/__init__.py
@@ -161,6 +161,8 @@ class Container:
         dictionary = {}
         for key in self.__slots__:
             value = getattr(self, key, None)
+            if isinstance(value, enum.Enum):
+                value = value.value
             try:
                 value = getattr(self, f'serialize_{key}')(value)
             except AttributeError:

--- a/golem_messages/datastructures/tasks.py
+++ b/golem_messages/datastructures/tasks.py
@@ -1,3 +1,4 @@
+import enum
 import functools
 import hashlib
 import logging
@@ -19,6 +20,10 @@ class TaskHeader(datastructures.Container):
     Task header describes general information about task as an request and
     is propagated in the network as an offer for computing nodes
     """
+
+    class MARKET_TYPE(datastructures.StringEnum):
+        Brass = enum.auto()
+        Usage = enum.auto()
 
     __slots__ = {
         'mask': (
@@ -55,7 +60,7 @@ class TaskHeader(datastructures.Container):
                 fail_msg="Subtask timeout is less than 0",
             ),
         ),
-        'market_type': (validators.validate_varchar128, ),
+        'market_type': (),
         # environment.get_id()
         'environment': (validators.validate_varchar128, ),
         'environment_prerequisites': (validators.validate_dict, ),
@@ -126,3 +131,14 @@ class TaskHeader(datastructures.Container):
     @classmethod
     def serialize_mask(cls, value):
         return value.to_bytes()
+
+    @classmethod
+    def deserialize_market_type(cls, value):
+        try:
+            return cls.MARKET_TYPE(value)
+        except ValueError as e:
+            raise exceptions.FieldError(
+                "Invalid value for MARKET_TYPE",
+                field='market_type',
+                value=value,
+            ) from e

--- a/golem_messages/datastructures/tasks.py
+++ b/golem_messages/datastructures/tasks.py
@@ -55,7 +55,7 @@ class TaskHeader(datastructures.Container):
                 fail_msg="Subtask timeout is less than 0",
             ),
         ),
-        'task_type': (validators.validate_varchar128, ),
+        'market_type': (validators.validate_varchar128, ),
         # environment.get_id()
         'environment': (validators.validate_varchar128, ),
         'environment_prerequisites': (validators.validate_dict, ),
@@ -77,7 +77,6 @@ class TaskHeader(datastructures.Container):
 
     REQUIRED = frozenset((
         'task_id',
-        'task_type',
         'task_owner',
         'subtasks_count',
         'min_version',

--- a/golem_messages/factories/datastructures/tasks.py
+++ b/golem_messages/factories/datastructures/tasks.py
@@ -3,6 +3,7 @@
 import datetime
 import factory
 
+from golem_messages import constants
 from golem_messages import cryptography
 from golem_messages.datastructures import masking
 from golem_messages.datastructures import tasks as dt_tasks
@@ -29,7 +30,7 @@ class TaskHeaderFactory(factory.Factory):
             o.requestor_public_key
         ),
     )
-    task_type = "dummy"
+    market_type = constants.MarketType.BRASS_MARKET
     task_owner = factory.LazyAttribute(
         lambda o: dt_p2p_factories.Node(
             key=o.requestor_public_key

--- a/golem_messages/factories/datastructures/tasks.py
+++ b/golem_messages/factories/datastructures/tasks.py
@@ -30,7 +30,7 @@ class TaskHeaderFactory(factory.Factory):
             o.requestor_public_key
         ),
     )
-    market_type = constants.MarketType.BRASS_MARKET
+    market_type = dt_tasks.TaskHeader.MARKET_TYPE.Brass
     task_owner = factory.LazyAttribute(
         lambda o: dt_p2p_factories.Node(
             key=o.requestor_public_key

--- a/tests/datastructures/test_tasks.py
+++ b/tests/datastructures/test_tasks.py
@@ -2,6 +2,7 @@ import datetime
 import time
 import unittest
 
+from golem_messages import constants
 from golem_messages import cryptography
 from golem_messages import idgenerator
 from golem_messages import utils
@@ -22,7 +23,7 @@ class TestTaskHeader(unittest.TestCase):
                 "pub_addr": "10.10.10.10",
                 "pub_port": 10101
             },
-            "task_type": "dummy",
+            "market_type": constants.MarketType.BRASS_MARKET,
             "environment": "DEFAULT",
             "deadline": int(time.time() + 1201),
             "subtask_timeout": 120,

--- a/tests/datastructures/test_tasks.py
+++ b/tests/datastructures/test_tasks.py
@@ -2,7 +2,6 @@ import datetime
 import time
 import unittest
 
-from golem_messages import constants
 from golem_messages import cryptography
 from golem_messages import idgenerator
 from golem_messages import utils
@@ -23,7 +22,7 @@ class TestTaskHeader(unittest.TestCase):
                 "pub_addr": "10.10.10.10",
                 "pub_port": 10101
             },
-            "market_type": constants.MarketType.BRASS_MARKET,
+            "market_type": dt_tasks.TaskHeader.MARKET_TYPE.Brass,
             "environment": "DEFAULT",
             "deadline": int(time.time() + 1201),
             "subtask_timeout": 120,


### PR DESCRIPTION
It should be merged before #358 as discussed with @mfranciszkiewicz we do not want to rely on task_type to get information about market type of the request. 

@jiivan What should I do about the release 3.12.0 which is basically a mistake? Can we take it down and make this change a 3.13.0? 