### PR TITLE
"subtask_id" independent of "task_id"

### DIFF
--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -428,16 +428,15 @@ class TaskToCompute(
         )
 
     def validate_taskid(self) -> None:
-        for key in ('task_id', 'subtask_id'):
-            value = self.compute_task_def[key]
-            if not idgenerator.check_id_hex_seed(value, self.requestor_id):
-                raise exceptions.FieldError(
-                    "Should be generated with node == ({node:x})".format(
-                        node=idgenerator.hex_seed_to_node(self.requestor_id),
-                    ),
-                    field=key,
-                    value=value,
-                )
+        value = self.compute_task_def['task_id']
+        if not idgenerator.check_id_hex_seed(value, self.requestor_id):
+            raise exceptions.FieldError(
+                "Should be generated with node == ({node:x})".format(
+                    node=idgenerator.hex_seed_to_node(self.requestor_id),
+                ),
+                field='task_id',
+                value=value,
+            )
 
     def validate_ownership(self, concent_public_key=None):
         self.want_to_compute_task.task_header.verify(

--- a/tests/message/tasks/test_task_to_compute.py
+++ b/tests/message/tasks/test_task_to_compute.py
@@ -87,9 +87,6 @@ class TaskToComputeTest(mixins.RegisteredMessageTestMixin,
     def test_spoofed_task_id(self):
         self._test_spoofed_id('task_id')
 
-    def test_spoofed_subtask_id(self):
-        self._test_spoofed_id('subtask_id')
-
     def test_golem_id_shortcut(self):
         task_id = 'tid'
         subtask_id = 'sid'


### PR DESCRIPTION
`subtask_id`s are no longer required to be derived from a `task_id`. Task API apps assign arbitrary `subtask_id`s.