### PR TITLE
Fix loading OpenSSL on macOS

### DIFF
--- a/golem_messages/cryptography.py
+++ b/golem_messages/cryptography.py
@@ -23,7 +23,11 @@ if sys.platform not in ('darwin', 'win32'):
 elif sys.platform == 'darwin':
     # FIX PATH ON OS X ()
     # https://github.com/yann2192/pyelliptic/issues/11
-    _openssl_lib_paths = ['/usr/local/Cellar/openssl/']
+    _openssl_lib_paths = [
+        '/usr/local/Cellar/openssl/',
+        '/usr/local/Cellar/openssl@1.1/'
+    ]
+
     for p in _openssl_lib_paths:
         if os.path.exists(p):
             p = os.path.join(p, os.listdir(p)[-1], 'lib')


### PR DESCRIPTION
On MacOS, the OpenSSL version required by Golem needs to be installed
via homebrew. Golem relies on a fixed path to where the library is
installed. As part of upgrade to OpenSSL version 1.1 the installation
path has changed. On newly set up systems this prevented Golem from
finding the library. This commit appends the new installation path
to the lookup array.