### PR TITLE
tasks.CannotComputeTask.REASON.CannotTakeWork

### DIFF
--- a/golem_messages/message/tasks.py
+++ b/golem_messages/message/tasks.py
@@ -740,6 +740,7 @@ class CannotComputeTask(TaskMessage, base.AbstractReasonMessage):
     ] + base.AbstractReasonMessage.__slots__
 
     class REASON(datastructures.StringEnum):
+        CannotTakeWork = enum.auto()
         WrongCTD = enum.auto()
         WrongKey = enum.auto()
         WrongAddress = enum.auto()


### PR DESCRIPTION
New reason for `CannotComputeTask` message